### PR TITLE
Switch to uint64 timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Each job send to a miner is a `BlockMiner` instance in hex format.
 
 The `BlockMiner` is in following format:
 - header work hash: 32 bytes
-- timestamp (u128 for milliseconds): 16 bytes
+- timestamp (u64 for milliseconds): 8 bytes
 - nonce (u64): 8 bytes (BigEndian format)
 - extra nonce: 32 bytes
 - miner public key: 32 bytes

--- a/xelis_common/src/api/daemon.rs
+++ b/xelis_common/src/api/daemon.rs
@@ -305,7 +305,7 @@ pub struct AccountHistoryEntry {
     pub hash: Hash,
     #[serde(flatten)]
     pub history_type: AccountHistoryType,
-    pub block_timestamp: u128
+    pub block_timestamp: u64
 }
 
 #[derive(Serialize, Deserialize)]

--- a/xelis_common/src/block/miner.rs
+++ b/xelis_common/src/block/miner.rs
@@ -13,14 +13,14 @@ use super::{EXTRA_NONCE_SIZE, BLOCK_WORK_SIZE};
 #[derive(Clone, Debug)]
 pub struct BlockMiner<'a> {
     pub header_work_hash: Hash, // include merkle tree of tips, txs, and height (immutable)
-    pub timestamp: u128, // miners can update timestamp to keep it up-to-date
+    pub timestamp: u64, // miners can update timestamp to keep it up-to-date
     pub nonce: u64,
     pub miner: Option<Cow<'a, PublicKey>>,
     pub extra_nonce: [u8; EXTRA_NONCE_SIZE]
 }
 
 impl<'a> BlockMiner<'a> {
-    pub fn new(header_work_hash: Hash, timestamp: u128) -> Self {
+    pub fn new(header_work_hash: Hash, timestamp: u64) -> Self {
         Self {
             header_work_hash,
             timestamp,
@@ -40,12 +40,12 @@ impl<'a> BlockMiner<'a> {
 impl<'a> Serializer for BlockMiner<'a> {
     fn write(&self, writer: &mut Writer) {
         writer.write_hash(&self.header_work_hash); // 32
-        writer.write_u128(&self.timestamp); // 32 + 16 = 48
-        writer.write_u64(&self.nonce); // 48 + 8 = 56
-        writer.write_bytes(&self.extra_nonce); // 56 + 32 = 88
+        writer.write_u64(&self.timestamp); // 32 + 8 = 40
+        writer.write_u64(&self.nonce); // 40 + 8 = 48
+        writer.write_bytes(&self.extra_nonce); // 48 + 32 = 80
 
         if let Some(miner) = &self.miner {
-            miner.write(writer); // 88 + 32 = 120
+            miner.write(writer); // 80 + 32 = 112
         }
 
         debug_assert!(writer.total_write() == BLOCK_WORK_SIZE, "invalid block work size");
@@ -57,7 +57,7 @@ impl<'a> Serializer for BlockMiner<'a> {
         }
 
         let header_work_hash = reader.read_hash()?;
-        let timestamp = reader.read_u128()?;
+        let timestamp = reader.read_u64()?;
         let nonce = reader.read_u64()?;
         let extra_nonce = reader.read_bytes_32()?;
         let miner = Some(Cow::Owned(PublicKey::read(reader)?));

--- a/xelis_common/src/block/mod.rs
+++ b/xelis_common/src/block/mod.rs
@@ -18,7 +18,7 @@ pub use miner::BlockMiner;
 
 pub const EXTRA_NONCE_SIZE: usize = 32;
 pub const HEADER_WORK_SIZE: usize = 73;
-pub const BLOCK_WORK_SIZE: usize = 120; // 32 + 16 + 8 + 32 + 32 = 120
+pub const BLOCK_WORK_SIZE: usize = 112; // 32 + 8 + 8 + 32 + 32 = 120
 
 pub fn serialize_extra_nonce<S: serde::Serializer>(extra_nonce: &[u8; EXTRA_NONCE_SIZE], s: S) -> Result<S::Ok, S::Error> {
     s.serialize_str(&hex::encode(extra_nonce))
@@ -32,13 +32,12 @@ pub fn deserialize_extra_nonce<'de, D: serde::Deserializer<'de>>(deserializer: D
     Ok(extra_nonce)
 }
 
-// transform it as u64, its good enough until serde is able to de/serialize u128
-pub fn serialize_timestamp<S: serde::Serializer>(timestamp: &u128, s: S) -> Result<S::Ok, S::Error> {
-    s.serialize_u64(*timestamp as u64)
+pub fn serialize_timestamp<S: serde::Serializer>(timestamp: &u64, s: S) -> Result<S::Ok, S::Error> {
+    s.serialize_u64(*timestamp)
 }
 
-pub fn deserialize_timestamp<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<u128, D::Error> {
-    Ok(u64::deserialize(deserializer)? as u128)
+pub fn deserialize_timestamp<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<u64, D::Error> {
+    Ok(u64::deserialize(deserializer)?)
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
@@ -47,7 +46,7 @@ pub struct BlockHeader {
     pub tips: IndexSet<Hash>,
     #[serde(serialize_with = "serialize_timestamp")]
     #[serde(deserialize_with = "deserialize_timestamp")]
-    pub timestamp: u128,
+    pub timestamp: u64,
     pub height: u64,
     pub nonce: u64,
     #[serde(serialize_with = "serialize_extra_nonce")]
@@ -65,7 +64,7 @@ pub struct Block {
 }
 
 impl BlockHeader {
-    pub fn new(version: u8, height: u64, timestamp: u128, tips: IndexSet<Hash>, extra_nonce: [u8; EXTRA_NONCE_SIZE], miner: PublicKey, txs_hashes: IndexSet<Hash>) -> Self {
+    pub fn new(version: u8, height: u64, timestamp: u64, tips: IndexSet<Hash>, extra_nonce: [u8; EXTRA_NONCE_SIZE], miner: PublicKey, txs_hashes: IndexSet<Hash>) -> Self {
         BlockHeader {
             version,
             height,
@@ -94,7 +93,7 @@ impl BlockHeader {
         self.height
     }
 
-    pub fn get_timestamp(&self) -> u128 {
+    pub fn get_timestamp(&self) -> u64 {
         self.timestamp
     }
 
@@ -236,19 +235,19 @@ impl Serializer for BlockHeader {
     fn write(&self, writer: &mut Writer) {
         writer.write_u8(self.version); // 1
         writer.write_u64(&self.height); // 1 + 8 = 9
-        writer.write_u128(&self.timestamp); // 9 + 16 = 25
-        writer.write_u64(&self.nonce); // 25 + 8 = 33
-        writer.write_bytes(&self.extra_nonce); // 33 + 32 = 65
-        writer.write_u8(self.tips.len() as u8); // 65 + 1 = 66
+        writer.write_u64(&self.timestamp); // 9 + 8 = 17
+        writer.write_u64(&self.nonce); // 17 + 8 = 25
+        writer.write_bytes(&self.extra_nonce); // 25 + 32 = 57
+        writer.write_u8(self.tips.len() as u8); // 57 + 1 = 58
         for tip in &self.tips {
             writer.write_hash(tip); // 32
         }
 
-        writer.write_u16(self.txs_hashes.len() as u16); // 66 + 2 = 68
+        writer.write_u16(self.txs_hashes.len() as u16); // 58 + 2 = 60
         for tx in &self.txs_hashes {
             writer.write_hash(tx); // 32
         }
-        self.miner.write(writer); // 68 + 32 = 100
+        self.miner.write(writer); // 60 + 32 = 92
     }
 
     fn read(reader: &mut Reader) -> Result<BlockHeader, ReaderError> {
@@ -260,7 +259,7 @@ impl Serializer for BlockHeader {
         }
 
         let height = reader.read_u64()?;
-        let timestamp = reader.read_u128()?;
+        let timestamp = reader.read_u64()?;
         let nonce = reader.read_u64()?;
         let extra_nonce: [u8; 32] = reader.read_bytes_32()?;
 

--- a/xelis_common/src/utils.rs
+++ b/xelis_common/src/utils.rs
@@ -30,8 +30,8 @@ pub fn get_current_time_in_seconds() -> u64 {
 }
 
 // return timestamp in milliseconds
-pub fn get_current_time_in_millis() -> u128 {
-    get_current_time().as_millis()
+pub fn get_current_time_in_millis() -> u64 {
+    get_current_time().as_millis() as u64
 }
 
 // Format any coin value using the requested decimals count

--- a/xelis_daemon/src/config.rs
+++ b/xelis_daemon/src/config.rs
@@ -34,7 +34,7 @@ pub const GENESIS_BLOCK_DIFFICULTY: Difficulty = 1;
 // 1024 * 1024 + (256 * 1024) bytes = 1.25 MB maximum size per block with txs
 pub const MAX_BLOCK_SIZE: usize = (1024 * 1024) + (256 * 1024);
 // 2 seconds maximum in future (prevent any attack on reducing difficulty but keep margin for unsynced devices)
-pub const TIMESTAMP_IN_FUTURE_LIMIT: u128 = 2 * 1000;
+pub const TIMESTAMP_IN_FUTURE_LIMIT: u64 = 2 * 1000;
 
 // keep at least last N blocks until top topoheight when pruning the chain
 pub const PRUNE_SAFETY_LIMIT: u64 = STABLE_LIMIT * 10;
@@ -62,7 +62,7 @@ pub const EMISSION_SPEED_FACTOR: u64 = 20;
 pub const MAXIMUM_SUPPLY: u64 = 18_400_000 * COIN_VALUE; // 18.4M full coin
 
 // Genesis block to have the same starting point for every nodes
-pub const GENESIS_BLOCK: &str = "0000000000000000000000000000000000000001872f3e0c02000000000000000000000000000000000000000000000000000000000000000000000000000000000000006c24cdc1c8ee8f028b8cafe7b79a66a0902f26d89dd54eeff80abcf251a9a3bd"; // Genesis block in hexadecimal format
+pub const GENESIS_BLOCK: &str = "000000000000000000000001872f3e0c02000000000000000000000000000000000000000000000000000000000000000000000000000000000000006c24cdc1c8ee8f028b8cafe7b79a66a0902f26d89dd54eeff80abcf251a9a3bd"; // Genesis block in hexadecimal format
 // Developer address for paying dev fees until Smart Contracts integration
 // (testnet/mainnet format is converted lazily later)
 pub const DEV_ADDRESS: &str = "xel1qyqxcfxdc8ywarcz3wx2leahnfn2pyp0ymvfm42waluq408j2x5680g05xfx5";

--- a/xelis_daemon/src/core/difficulty.rs
+++ b/xelis_daemon/src/core/difficulty.rs
@@ -11,7 +11,7 @@ const FACTOR: i64 = 10000;
 // Calculate the difficulty for the next block
 // Difficulty jump can happen easily but drop is limited to 2x the block time
 // This is to prevent any attack on the difficulty where a miner would try to manipulate the network
-pub fn calculate_difficulty_v1(parent_timestamp: u128, new_timestamp: u128, previous_difficulty: Difficulty) -> Difficulty {
+pub fn calculate_difficulty_v1(parent_timestamp: u64, new_timestamp: u64, previous_difficulty: Difficulty) -> Difficulty {
     let mut solve_time = (new_timestamp - parent_timestamp) as f64;
 
     // Limit to 2x the block time to prevent any too-big difficulty drop
@@ -34,7 +34,7 @@ const DIFFICULTY_BOUND_DIVISOR: u64 = 2048;
 const CHAIN_TIME_RANGE: u64 = BLOCK_TIME_MILLIS * 2 / 3;
 
 // Difficulty algorithm from Ethereum: Homestead but tweaked for our needs
-pub fn calculate_difficulty(tips_count: u64, parent_timestamp: u128, new_timestamp: u128, previous_difficulty: Difficulty) -> Difficulty {
+pub fn calculate_difficulty(tips_count: u64, parent_timestamp: u64, new_timestamp: u64, previous_difficulty: Difficulty) -> Difficulty {
     // For current testnet, keep using same algorithm
     if true {
         return calculate_difficulty_v1(parent_timestamp, new_timestamp, previous_difficulty);

--- a/xelis_daemon/src/core/error.rs
+++ b/xelis_daemon/src/core/error.rs
@@ -25,9 +25,9 @@ pub enum BlockchainError {
     #[error("Transaction size is {} while limit is {}", human_bytes(*_0 as f64), human_bytes(*_1 as f64))]
     TxTooBig(usize, usize),
     #[error("Timestamp {} is less than parent", _0)]
-    TimestampIsLessThanParent(u128),
+    TimestampIsLessThanParent(u64),
     #[error("Timestamp {} is greater than current time {}", _0, _1)]
-    TimestampIsInFuture(u128, u128), // left is expected, right is got
+    TimestampIsInFuture(u64, u64), // left is expected, right is got
     #[error("Block height mismatch, expected {}, got {}.", _0, _1)]
     InvalidBlockHeight(u64, u64),
     #[error("Block height is in stable height which is not allowed")]

--- a/xelis_daemon/src/core/storage/mod.rs
+++ b/xelis_daemon/src/core/storage/mod.rs
@@ -22,7 +22,7 @@ pub type Tips = HashSet<Hash>;
 #[async_trait]
 pub trait DifficultyProvider {
     async fn get_height_for_block_hash(&self, hash: &Hash) -> Result<u64, BlockchainError>;
-    async fn get_timestamp_for_block_hash(&self, hash: &Hash) -> Result<u128, BlockchainError>;
+    async fn get_timestamp_for_block_hash(&self, hash: &Hash) -> Result<u64, BlockchainError>;
     async fn get_difficulty_for_block_hash(&self, hash: &Hash) -> Result<Difficulty, BlockchainError>;
     async fn get_cumulative_difficulty_for_block_hash(&self, hash: &Hash) -> Result<Difficulty, BlockchainError>;
     async fn get_past_blocks_for_block_hash(&self, hash: &Hash) -> Result<Immutable<IndexSet<Hash>>, BlockchainError>;

--- a/xelis_daemon/src/core/storage/sled.rs
+++ b/xelis_daemon/src/core/storage/sled.rs
@@ -359,7 +359,7 @@ impl DifficultyProvider for SledStorage {
         Ok(block.get_height())
     }
 
-    async fn get_timestamp_for_block_hash(&self, hash: &Hash) -> Result<u128, BlockchainError> {
+    async fn get_timestamp_for_block_hash(&self, hash: &Hash) -> Result<u64, BlockchainError> {
         trace!("get timestamp for hash {}", hash);
         let block = self.get_block_header_by_hash(hash).await?;
         Ok(block.get_timestamp())

--- a/xelis_daemon/src/p2p/chain_validator.rs
+++ b/xelis_daemon/src/p2p/chain_validator.rs
@@ -112,7 +112,7 @@ impl<S: Storage> DifficultyProvider for ChainValidator<S> {
         Ok(storage.get_height_for_block_hash(hash).await?)
     }
 
-    async fn get_timestamp_for_block_hash(&self, hash: &Hash) -> Result<u128, BlockchainError> {
+    async fn get_timestamp_for_block_hash(&self, hash: &Hash) -> Result<u64, BlockchainError> {
         if let Some(data) = self.blocks.get(hash) {
             return Ok(data.header.get_timestamp())
         }

--- a/xelis_daemon/src/p2p/mod.rs
+++ b/xelis_daemon/src/p2p/mod.rs
@@ -565,7 +565,7 @@ impl<S: Storage> P2pServer<S> {
 
     async fn chain_sync_loop(self: Arc<Self>) {
         // used to detect how much time we have to wait before next request
-        let mut last_chain_sync: u128 = get_current_time_in_millis();
+        let mut last_chain_sync: u64 = get_current_time_in_millis();
         let interval = Duration::from_secs(CHAIN_SYNC_DELAY);
         // Try to not reuse the same peer between each sync
         let mut previous_peer: Option<Arc<Peer>> = None;
@@ -2138,7 +2138,7 @@ impl<S: Storage> P2pServer<S> {
     // we send up to CHAIN_SYNC_REQUEST_MAX_BLOCKS blocks id (combinaison of block hash and topoheight)
     // we add at the end the genesis block to be sure to be on the same chain as others peers
     // its used to find a common point with the peer to which we ask the chain
-    pub async fn request_sync_chain_for(&self, peer: &Arc<Peer>, last_chain_sync: &mut u128) -> Result<(), BlockchainError> {
+    pub async fn request_sync_chain_for(&self, peer: &Arc<Peer>, last_chain_sync: &mut u64) -> Result<(), BlockchainError> {
         trace!("Requesting chain from {}", peer);
 
         // This can be configured by the node operator, it will be adjusted between protocol bounds

--- a/xelis_daemon/src/rpc/getwork_server.rs
+++ b/xelis_daemon/src/rpc/getwork_server.rs
@@ -37,7 +37,7 @@ impl TMessage for Response {
 }
 
 pub struct Miner {
-    first_seen: u128, // timestamp of first connection
+    first_seen: u64, // timestamp of first connection
     key: PublicKey, // public key of account (address)
     name: String, // worker name
     blocks_accepted: usize, // blocks accepted by us since he is connected
@@ -55,7 +55,7 @@ impl Miner {
         }
     }
 
-    pub fn first_seen(&self) -> u128 {
+    pub fn first_seen(&self) -> u64 {
         self.first_seen
     }
 
@@ -157,8 +157,8 @@ pub struct GetWorkServer<S: Storage> {
     mining_jobs: Mutex<LruCache<Hash, (BlockHeader, Difficulty)>>,
     last_header_hash: Mutex<Option<Hash>>,
     // used only when a new TX is received in mempool
-    last_notify: Mutex<u128>,
-    notify_rate_limit_ms: u128
+    last_notify: Mutex<u64>,
+    notify_rate_limit_ms: u64
 }
 
 impl<S: Storage> GetWorkServer<S> {


### PR DESCRIPTION
## Description

This switches from u128 to u64 for a more compact timestamps representation.
The u64 value is enough to represent ~584942417 years in milliseconds.

I have reviewed and tested the changes. Daemon is finding blocks successfully in test-net. However, an external review is needed.

Closes https://github.com/xelis-project/xelis-blockchain/issues/18 .

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Which part is impacted ?

  - [X] Daemon
  - [ ] Wallet
  - [X] Miner
  - [X] Misc (documentation, comments, text...)

## Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings