### PR TITLE
Proper dependency caching in the CI, and Docker Hub cache registry

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.gitignore
+target/
+API.md
+README.md
+build_all.sh

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -64,8 +64,8 @@ jobs:
           push: ${{ env.SHOULD_PUSH }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=xelis/${{ matrix.app }}:buildcache
+          cache-to: type=registry,ref=xelis/${{ matrix.app }}:buildcache,mode=max
           build-args: |
             app=xelis_${{ matrix.app }}
             commit_hash=${{ github.sha }}


### PR DESCRIPTION
## Description

- Dependencies will now be cached in the Docker CI
- Docker Hub is now used instead of GitHub as cache registry, since it has no space limit

## Type of change

Please select the right one.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Which part is impacted ?

  - [ ] Daemon
  - [ ] Wallet
  - [ ] Miner
  - [x] Misc (documentation, comments, text...)

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings