### PR TITLE
ci: using github action cache again for docker images, disabled cache pushing on pull request

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -64,8 +64,8 @@ jobs:
           push: ${{ env.SHOULD_PUSH }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=xelis/${{ matrix.app }}:buildcache
-          cache-to: type=registry,ref=xelis/${{ matrix.app }}:buildcache,mode=max
+          cache-from: type=gha
+          cache-to: ${{ env.SHOULD_PUSH && 'type=gha,mode=max' || '' }}
           build-args: |
             app=xelis_${{ matrix.app }}
             commit_hash=${{ github.sha }}


### PR DESCRIPTION
## Description

- Docker image build cache now uses Github action cache again
- CI will not try to push to cache when building from a pull request

## Type of change

Please select the right one.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Which part is impacted ?

  - [ ] Daemon
  - [ ] Wallet
  - [ ] Miner
  - [x] Misc (documentation, comments, text...)

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings