### PR TITLE
validate_address return value as object

### DIFF
--- a/API.md
+++ b/API.md
@@ -470,9 +470,11 @@ Validate a wallet address by accepting or not integrated address.
 ##### Response
 ```json
 {
-    "id": 1,
-    "jsonrpc": "2.0",
-    "result": true
+  "id": 1,
+  "jsonrpc": "2.0",
+  "result": {
+    "is_valid": true
+  }
 }
 ```
 

--- a/xelis_common/src/api/daemon.rs
+++ b/xelis_common/src/api/daemon.rs
@@ -481,6 +481,11 @@ pub struct ValidateAddressParams<'a> {
 }
 
 #[derive(Serialize, Deserialize)]
+pub struct ValidateAddressResult {
+    pub is_valid: bool
+}
+
+#[derive(Serialize, Deserialize)]
 pub struct ExtractKeyFromAddressParams<'a> {
     pub address: Cow<'a, Address>,
     #[serde(default)]

--- a/xelis_daemon/src/rpc/rpc.rs
+++ b/xelis_daemon/src/rpc/rpc.rs
@@ -66,7 +66,8 @@ use xelis_common::{
             SubmitTransactionParams,
             TransactionResponse,
             ValidateAddressParams,
-            ExtractKeyFromAddressParams
+            ExtractKeyFromAddressParams,
+            ValidateAddressResult
         },
         RPCTransaction,
         RPCTransactionType as RPCTransactionType
@@ -1177,9 +1178,13 @@ async fn validate_address<S: Storage>(_: Context, body: Value) -> Result<Value, 
     let params: ValidateAddressParams = parse_params(body)?;
 
     if !params.allow_integrated {
-        Ok(json!(params.address.is_normal()))
+        Ok(json!(ValidateAddressResult {
+            is_valid: params.address.is_normal()
+        }))
     } else {
-        Ok(json!(true))
+        Ok(json!(ValidateAddressResult {
+            is_valid: true
+        }))
     }
 }
 


### PR DESCRIPTION
## Description

This change updates the node response to be an object with `is_valid` (as the current only param), but is meant for future handling if need to add parameters without breaking existing integrations.

## Type of change

Please select the right one.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update

## Which part is impacted ?

  - [X] Daemon
  - [ ] Wallet
  - [ ] Miner
  - [X] Misc (documentation, comments, text...)

## Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings