### PR TITLE
v1.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3408,6 +3408,7 @@ dependencies = [
  "async-trait",
  "blake3",
  "bulletproofs",
+ "chacha20",
  "chacha20poly1305",
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
 
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "xelis_common"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -3439,7 +3439,7 @@ dependencies = [
 
 [[package]]
 name = "xelis_daemon"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "actix",
  "actix-web",
@@ -3470,7 +3470,7 @@ dependencies = [
 
 [[package]]
 name = "xelis_miner"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3488,7 +3488,7 @@ dependencies = [
 
 [[package]]
 name = "xelis_wallet"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "actix",
  "actix-web",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,16 +46,16 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d223b13fd481fc0d1f83bb12659ae774d9e3601814c68a0bc539731698cca743"
+checksum = "4eb9843d84c775696c37d9a418bbb01b932629d01870722c0f13eb3f95e2536d"
 dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-utils",
  "ahash",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitflags 2.5.0",
  "brotli",
  "bytes",
@@ -90,18 +90,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.63",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "actix-router"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22475596539443685426b6bdadb926ad0ecaefdfc5fb05e5e3441f15463c511"
+checksum = "13d324164c51f63867b57e73ba5936ea151b8a41a1d23d1031eeb9f70d0236f8"
 dependencies = [
  "bytestring",
+ "cfg-if",
  "http 0.2.12",
  "regex",
+ "regex-lite",
  "serde",
  "tracing",
 ]
@@ -157,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.5.1"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a6556ddebb638c2358714d853257ed226ece6023ef9364f23f0c70737ea984"
+checksum = "b1cf67dadb19d7c95e5a299e2dda24193b89d5d4f33a3b9800888ede9e19aa32"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -186,6 +188,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "regex",
+ "regex-lite",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -222,7 +225,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -261,7 +264,7 @@ checksum = "7c7db3d5a9718568e4cf4a537cfd7070e6e6ff7481510d0237fb529ac850f6d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -409,9 +412,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.83"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "argon2"
@@ -444,7 +447,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -466,7 +469,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -477,7 +480,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -630,9 +633,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "3.5.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
+checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -641,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.5.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
+checksum = "e6221fe77a248b9117d431ad93761222e1cf8ff282d9d1d5d9f53d6299a1cf76"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -692,13 +695,13 @@ dependencies = [
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4da9a32f3fed317401fa3c862968128267c3106685286e15d5aaa3d7389c2f60"
+checksum = "369cfaf2a5bed5d8f8202073b2e093c9f508251de1551a0deb4253e4c7d80909"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -724,9 +727,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
+checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
 dependencies = [
  "jobserver",
  "libc",
@@ -819,7 +822,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -941,18 +944,18 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -968,9 +971,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crossterm"
@@ -1053,7 +1056,7 @@ source = "git+https://github.com/xelis-project/curve25519-dalek?branch=main#1ff0
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1129,9 +1132,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
 name = "encoding_rs"
@@ -1251,7 +1254,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1592,9 +1595,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
 ]
@@ -1678,9 +1681,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.154"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "local-channel"
@@ -1771,9 +1774,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
 dependencies = [
  "adler",
 ]
@@ -1966,7 +1969,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2033,18 +2036,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
+checksum = "0b33eb56c327dec362a9e55b3ad14f9d2f0904fb5a5b03b513ab5465399e9f43"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prost"
-version = "0.12.4"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f5d036824e4761737860779c906171497f6d55681139d8312388f8fe398922"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2052,22 +2055,22 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9554e3ab233f0a932403704f1a1d08c30d5ccd931adfdfa1e8b5a19b52c1d55a"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.12.4"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3235c33eb02c1f1e212abdbe34c78b264b038fb58ca612664343271e36e55ffe"
+checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
  "prost",
 ]
@@ -2209,6 +2212,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b661b2f27137bdbc16f00eda72866a92bb28af1753ffbd56744fb6e2e9cd8e"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2337,9 +2346,9 @@ checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.3"
+version = "0.102.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3bce581c0dd41bce533ce695a1437fa16a7ab5ac3ccfa99fe1a620a7885eabf"
+checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2348,9 +2357,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092474d1a01ea8278f69e6a358998405fae5b8b963ddaeb2b0b04a128bf1dfb0"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "ryu"
@@ -2404,22 +2413,22 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.201"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c"
+checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.201"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
+checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2612,9 +2621,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.63"
+version = "2.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf5be731623ca1a1fb7d8be6f261a3be6d3e2337b8a1f97be944d020c8fcb704"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2656,22 +2665,22 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "thiserror"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2777,7 +2786,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2834,9 +2843,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 
 [[package]]
 name = "toml_edit"
@@ -2928,7 +2937,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3115,7 +3124,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.66",
  "wasm-bindgen-shared",
 ]
 
@@ -3149,7 +3158,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.66",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3533,7 +3542,7 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3553,7 +3562,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.66",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
 

--- a/xelis_common/Cargo.toml
+++ b/xelis_common/Cargo.toml
@@ -46,6 +46,7 @@ tokio-tungstenite = { version = "0.21", features = ["rustls-tls-webpki-roots"] }
 # Used for U256
 primitive-types = { version = "0.12.2", features = ["serde"] }
 console-subscriber = { version = "0.2.0", optional = true }
+chacha20 = "0.9.1"
 
 [target.'cfg(windows)'.dependencies]
 win32console = "0.1.5"

--- a/xelis_common/Cargo.toml
+++ b/xelis_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xelis_common"
-version = "1.11.0"
+version = "1.12.0"
 edition = "2021"
 authors = ["Slixe <slixeprivate@gmail.com>"]
 build = "build.rs"

--- a/xelis_common/src/api/daemon.rs
+++ b/xelis_common/src/api/daemon.rs
@@ -482,7 +482,9 @@ pub struct GetDifficultyResult {
 pub struct ValidateAddressParams<'a> {
     pub address: Cow<'a, Address>,
     #[serde(default)]
-    pub allow_integrated: bool
+    pub allow_integrated: bool,
+    #[serde(default)]
+    pub max_integrated_data_size: Option<usize>
 }
 
 #[derive(Serialize, Deserialize)]

--- a/xelis_common/src/api/daemon.rs
+++ b/xelis_common/src/api/daemon.rs
@@ -257,6 +257,14 @@ pub struct GetTransactionParams<'a> {
     pub hash: Cow<'a, Hash>
 }
 
+pub type GetTransactionExecutorParams<'a> = GetTransactionParams<'a>;
+
+#[derive(Serialize, Deserialize)]
+pub struct GetTransactionExecutorResult<'a> {
+    pub block_topoheight: u64,
+    pub block_hash: Cow<'a, Hash>
+}
+
 // Direction is used for cache to knows from which context it got added
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Direction {

--- a/xelis_common/src/api/mod.rs
+++ b/xelis_common/src/api/mod.rs
@@ -16,7 +16,7 @@ use crate::{
         Signature
     },
     transaction::{
-        aead::AEADCipher,
+        extra_data::AEADCipher,
         BurnPayload,
         Reference,
         SourceCommitment,

--- a/xelis_common/src/api/mod.rs
+++ b/xelis_common/src/api/mod.rs
@@ -16,7 +16,7 @@ use crate::{
         Signature
     },
     transaction::{
-        extra_data::AEADCipher,
+        extra_data::UnknownExtraDataFormat,
         BurnPayload,
         Reference,
         SourceCommitment,
@@ -50,7 +50,7 @@ pub struct DataHash<'a, T: Clone> {
 pub struct RPCTransferPayload<'a> {
     pub asset: Cow<'a, Hash>,
     pub destination: Address,
-    pub extra_data: Cow<'a, Option<AEADCipher>>,
+    pub extra_data: Cow<'a, Option<UnknownExtraDataFormat>>,
     pub commitment: Cow<'a, CompressedCommitment>,
     pub sender_handle: Cow<'a, CompressedHandle>,
     pub receiver_handle: Cow<'a, CompressedHandle>,

--- a/xelis_common/src/prompt/mod.rs
+++ b/xelis_common/src/prompt/mod.rs
@@ -367,11 +367,16 @@ impl State {
     }
 
     fn show_with_prompt_and_input(&self, prompt: &String, input: &String) -> Result<(), PromptError> {
+        // if not interactive, we don't need to show anything
+        if !self.is_interactive() {
+            return Ok(())
+        }
+
         let current_count = self.count_lines(&format!("\r{}{}", prompt, input));
         let previous_count = self.previous_prompt_line.swap(current_count, Ordering::SeqCst);
 
         // > 1 because prompt line is already counted below
-        if self.is_interactive() && previous_count > 1 {
+        if previous_count > 1 {
             print!("\x1B[{}A\x1B[J", previous_count - 1);
         }
 

--- a/xelis_common/src/prompt/mod.rs
+++ b/xelis_common/src/prompt/mod.rs
@@ -633,7 +633,7 @@ impl Prompt {
         Ok(res == "y")
     }
 
-    pub async fn read<F: FromStr>(&self, prompt: String) -> Result<F, PromptError>
+    pub async fn read<F: FromStr, S: ToString>(&self, prompt: S) -> Result<F, PromptError>
     where
         <F as FromStr>::Err: Display
     {
@@ -641,7 +641,7 @@ impl Prompt {
         value.parse().map_err(|e: F::Err| PromptError::ParseInputError(e.to_string()))
     }
 
-    pub async fn read_hash(&self, prompt: String) -> Result<Hash, PromptError> {
+    pub async fn read_hash<S: ToString>(&self, prompt: S) -> Result<Hash, PromptError> {
         let hash_hex = self.read_input(prompt, false).await?;
         Ok(Hash::from_hex(hash_hex)?)
     }
@@ -652,7 +652,7 @@ impl Prompt {
     }
 
     // read a message from the user and apply the input mask if necessary
-    pub async fn read_input(&self, prompt: String, apply_mask: bool) -> Result<String, PromptError> {
+    pub async fn read_input<S: ToString>(&self, prompt: S, apply_mask: bool) -> Result<String, PromptError> {
         // This is also used as a sempahore to have only one call at a time
         let mut canceler = self.read_input_receiver.lock().await;
 
@@ -683,7 +683,7 @@ impl Prompt {
         }
 
         // update the prompt to the requested one and keep blocking on the receiver
-        self.update_prompt(prompt)?;
+        self.update_prompt(prompt.to_string())?;
         let input = {
             let input = tokio::select! {
                 Some(()) = canceler.recv() => {

--- a/xelis_common/src/serializer/defaults.rs
+++ b/xelis_common/src/serializer/defaults.rs
@@ -20,12 +20,12 @@ impl Serializer for HashSet<Hash> {
 
     fn read(reader: &mut Reader) -> Result<Self, ReaderError> {
         let total_size = reader.total_size();
-        if total_size % 32 != 0 {
+        if total_size % HASH_SIZE != 0 {
             error!("Invalid size: {}, expected a multiple of 32 for hashes", total_size);
             return Err(ReaderError::InvalidSize)
         }
 
-        let count = total_size / 32;
+        let count = total_size / HASH_SIZE;
         let mut tips = HashSet::with_capacity(count);
         for _ in 0..count {
             let hash = reader.read_hash()?;

--- a/xelis_common/src/transaction/builder.rs
+++ b/xelis_common/src/transaction/builder.rs
@@ -44,7 +44,7 @@ use crate::{
 };
 use thiserror::Error;
 use super::{
-    extra_data::{ExtraData, PlaintextData, TAG_SIZE},
+    extra_data::{ExtraData, PlaintextData},
     BurnPayload,
     Reference,
     Role,
@@ -301,8 +301,8 @@ impl TransactionBuilder {
                         // 2 represents u16 length of AEADCipher in extra data
                         // 2 represents u16 length of UnknownExtraDataFormat
                         // We have both length has we move one in the other
-                        // This mean new ExtraData version has 2 + 2 + 32 (sender) + 32 (receiver) + 16 (tag) bytes of overhead.
-                        size += 2 + 2 + (RISTRETTO_COMPRESSED_SIZE * 2) + TAG_SIZE + extra_data.size();
+                        // This mean new ExtraData version has 2 + 2 + 32 (sender) + 32 (receiver) bytes of overhead.
+                        size += 2 + 2 + (RISTRETTO_COMPRESSED_SIZE * 2) + extra_data.size();
                     }
                 }
                 transfers.len()

--- a/xelis_common/src/transaction/builder.rs
+++ b/xelis_common/src/transaction/builder.rs
@@ -596,7 +596,7 @@ impl TransactionBuilder {
                             return Err(GenerationError::EncryptedExtraDataTooLarge);
                         }
 
-                        Some(cipher)
+                        Some(cipher.into())
                     } else {
                         None
                     };

--- a/xelis_common/src/transaction/builder.rs
+++ b/xelis_common/src/transaction/builder.rs
@@ -44,7 +44,7 @@ use crate::{
 };
 use thiserror::Error;
 use super::{
-    aead::{derive_aead_key_from_opening, PlaintextData, TAG_SIZE},
+    extra_data::{derive_aead_key_from_opening, PlaintextData, TAG_SIZE},
     BurnPayload,
     Reference,
     Role,

--- a/xelis_common/src/transaction/extra_data.rs
+++ b/xelis_common/src/transaction/extra_data.rs
@@ -149,17 +149,21 @@ pub enum ExtraDataVariant {
 
 impl Serializer for ExtraData {
     fn write(&self, writer: &mut Writer) {
-        self.cipher.write(writer);
         self.sender_handle.write(writer); 
         self.receiver_handle.write(writer);
+        self.cipher.write(writer);
     }
 
     fn read(reader: &mut Reader) -> Result<Self, ReaderError> {
         Ok(Self {
-            cipher: AEADCipher::read(reader)?,
             sender_handle: CompressedHandle::read(reader)?,
-            receiver_handle: CompressedHandle::read(reader)?
+            receiver_handle: CompressedHandle::read(reader)?,
+            cipher: AEADCipher::read(reader)?,
         })
+    }
+
+    fn size(&self) -> usize {
+        self.cipher.size() + self.sender_handle.size() + self.receiver_handle.size()
     }
 }
 
@@ -210,6 +214,12 @@ impl AEADCipher {
 impl From<AEADCipher> for UnknownExtraDataFormat {
     fn from(value: AEADCipher) -> Self {
         Self(value.0)
+    }
+}
+
+impl From<ExtraData> for UnknownExtraDataFormat {
+    fn from(value: ExtraData) -> Self {
+        Self(value.to_bytes())
     }
 }
 

--- a/xelis_common/src/transaction/mod.rs
+++ b/xelis_common/src/transaction/mod.rs
@@ -12,7 +12,7 @@ use crate::{
 use bulletproofs::RangeProof;
 use log::debug;
 use serde::{Deserialize, Serialize};
-use self::extra_data::AEADCipher;
+use self::extra_data::UnknownExtraDataFormat;
 
 pub mod builder;
 pub mod verify;
@@ -60,7 +60,7 @@ pub struct TransferPayload {
     asset: Hash,
     destination: CompressedPublicKey,
     // we can put whatever we want up to EXTRA_DATA_LIMIT_SIZE bytes
-    extra_data: Option<AEADCipher>,
+    extra_data: Option<UnknownExtraDataFormat>,
     /// Represents the ciphertext along with `sender_handle` and `receiver_handle`.
     /// The opening is reused for both of the sender and receiver commitments.
     commitment: CompressedCommitment,
@@ -110,7 +110,7 @@ pub struct Transaction {
 
 impl TransferPayload {
     // Create a new transfer payload
-    pub fn new(asset: Hash, destination: CompressedPublicKey, extra_data: Option<AEADCipher>, commitment: CompressedCommitment, sender_handle: CompressedHandle, receiver_handle: CompressedHandle, ct_validity_proof: CiphertextValidityProof) -> Self {
+    pub fn new(asset: Hash, destination: CompressedPublicKey, extra_data: Option<UnknownExtraDataFormat>, commitment: CompressedCommitment, sender_handle: CompressedHandle, receiver_handle: CompressedHandle, ct_validity_proof: CiphertextValidityProof) -> Self {
         TransferPayload {
             asset,
             destination,
@@ -133,7 +133,7 @@ impl TransferPayload {
     }
 
     // Get the extra data if any
-    pub fn get_extra_data(&self) -> &Option<AEADCipher> {
+    pub fn get_extra_data(&self) -> &Option<UnknownExtraDataFormat> {
         &self.extra_data
     }
 
@@ -167,7 +167,7 @@ impl TransferPayload {
     }
 
     // Take all data
-    pub fn consume(self) -> (Hash, CompressedPublicKey, Option<AEADCipher>, CompressedCommitment, CompressedHandle, CompressedHandle) {
+    pub fn consume(self) -> (Hash, CompressedPublicKey, Option<UnknownExtraDataFormat>, CompressedCommitment, CompressedHandle, CompressedHandle) {
         (self.asset, self.destination, self.extra_data, self.commitment, self.sender_handle, self.receiver_handle)
     }
 }

--- a/xelis_common/src/transaction/mod.rs
+++ b/xelis_common/src/transaction/mod.rs
@@ -12,11 +12,11 @@ use crate::{
 use bulletproofs::RangeProof;
 use log::debug;
 use serde::{Deserialize, Serialize};
-use self::aead::AEADCipher;
+use self::extra_data::AEADCipher;
 
 pub mod builder;
 pub mod verify;
-pub mod aead;
+pub mod extra_data;
 
 #[cfg(test)]
 mod tests;

--- a/xelis_common/src/transaction/tests.rs
+++ b/xelis_common/src/transaction/tests.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use super::{
     extra_data::{
-        derive_aead_key_from_opening,
+        derive_shared_key_from_opening,
         PlaintextData
     },
     builder::{
@@ -114,16 +114,15 @@ fn create_tx_for(account: Account, destination: Address, amount: u64, extra_data
 #[test]
 fn test_encrypt_decrypt() {
     let r = PedersenOpening::generate_new();
-    let key = derive_aead_key_from_opening(&r);
+    let key = derive_shared_key_from_opening(&r);
     let message = "Hello, World!".as_bytes().to_vec();
 
     let plaintext = PlaintextData(message.clone());
-    let cipher = plaintext.encrypt_in_place(&key);
+    let cipher = plaintext.encrypt_in_place_with_aead(&key);
     let decrypted = cipher.decrypt_in_place(&key).unwrap();
 
     assert_eq!(decrypted.0, message);
 }
-
 
 #[test]
 fn test_encrypt_decrypt_two_parties() {

--- a/xelis_common/src/transaction/tests.rs
+++ b/xelis_common/src/transaction/tests.rs
@@ -16,7 +16,6 @@ use crate::{
 };
 use super::{
     extra_data::{
-        derive_aead_key_from_ct,
         derive_aead_key_from_opening,
         PlaintextData
     },
@@ -147,24 +146,21 @@ fn test_encrypt_decrypt_two_parties() {
     // Verify the extra data from alice (sender)
     {
         let alice_ct = transfer.get_ciphertext(Role::Sender).decompress().unwrap();
-        let key = derive_aead_key_from_ct(&alice.keypair.get_private_key(), &alice_ct);
-        let decrypted = cipher.clone().decrypt_in_place(&key).unwrap();
-        assert_eq!(decrypted.0, payload.to_bytes());
+        let decrypted = cipher.decrypt_v1(&alice.keypair.get_private_key(), alice_ct.handle()).unwrap();
+        assert_eq!(decrypted, payload);
     }
 
     // Verify the extra data from bob (receiver)
     {
         let bob_ct = transfer.get_ciphertext(Role::Receiver).decompress().unwrap();
-        let key = derive_aead_key_from_ct(&bob.keypair.get_private_key(), &bob_ct);
-        let decrypted = cipher.clone().decrypt_in_place(&key).unwrap();
-        assert_eq!(decrypted.0, payload.to_bytes());
+        let decrypted = cipher.decrypt_v1(&bob.keypair.get_private_key(), bob_ct.handle()).unwrap();
+        assert_eq!(decrypted, payload);
     }
 
     // Verify the extra data from alice (sender) with the wrong key
     {
         let alice_ct = transfer.get_ciphertext(Role::Sender).decompress().unwrap();
-        let key = derive_aead_key_from_ct(&bob.keypair.get_private_key(), &alice_ct);
-        let decrypted = cipher.decrypt_in_place(&key);
+        let decrypted = cipher.decrypt_v1(&bob.keypair.get_private_key(), alice_ct.handle());
         assert!(decrypted.is_err());
     }
 }

--- a/xelis_common/src/transaction/tests.rs
+++ b/xelis_common/src/transaction/tests.rs
@@ -105,7 +105,7 @@ fn create_tx_for(account: Account, destination: Address, amount: u64, extra_data
     let builder = TransactionBuilder::new(0, account.keypair.get_public_key().compress(), data, FeeBuilder::Multiplier(1f64));
     let estimated_size = builder.estimate_size();
     let tx = builder.build(&mut state, &account.keypair).unwrap();
-    assert!(estimated_size == tx.size());
+    assert!(estimated_size == tx.size(), "expected {} bytes got {} bytes", tx.size(), estimated_size);
     assert!(tx.to_bytes().len() == estimated_size);
 
     tx
@@ -145,22 +145,19 @@ fn test_encrypt_decrypt_two_parties() {
     let cipher = transfer.extra_data.clone().unwrap();
     // Verify the extra data from alice (sender)
     {
-        let alice_ct = transfer.get_ciphertext(Role::Sender).decompress().unwrap();
-        let decrypted = cipher.decrypt_v1(&alice.keypair.get_private_key(), alice_ct.handle()).unwrap();
+        let decrypted = cipher.decrypt_v2(&alice.keypair.get_private_key(), Role::Sender).unwrap();
         assert_eq!(decrypted, payload);
     }
 
     // Verify the extra data from bob (receiver)
     {
-        let bob_ct = transfer.get_ciphertext(Role::Receiver).decompress().unwrap();
-        let decrypted = cipher.decrypt_v1(&bob.keypair.get_private_key(), bob_ct.handle()).unwrap();
+        let decrypted = cipher.decrypt_v2(&bob.keypair.get_private_key(), Role::Receiver).unwrap();
         assert_eq!(decrypted, payload);
     }
 
     // Verify the extra data from alice (sender) with the wrong key
     {
-        let alice_ct = transfer.get_ciphertext(Role::Sender).decompress().unwrap();
-        let decrypted = cipher.decrypt_v1(&bob.keypair.get_private_key(), alice_ct.handle());
+        let decrypted = cipher.decrypt_v2(&bob.keypair.get_private_key(), Role::Sender);
         assert!(decrypted.is_err());
     }
 }

--- a/xelis_common/src/transaction/tests.rs
+++ b/xelis_common/src/transaction/tests.rs
@@ -15,7 +15,7 @@ use crate::{
     transaction::{TransactionType, MAX_TRANSFER_COUNT}
 };
 use super::{
-    aead::{
+    extra_data::{
         derive_aead_key_from_ct,
         derive_aead_key_from_opening,
         PlaintextData

--- a/xelis_daemon/Cargo.toml
+++ b/xelis_daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xelis_daemon"
-version = "1.11.0"
+version = "1.12.0"
 edition = "2021"
 authors = ["Slixe <slixeprivate@gmail.com>"]
 

--- a/xelis_daemon/src/core/blockchain.rs
+++ b/xelis_daemon/src/core/blockchain.rs
@@ -1929,6 +1929,7 @@ impl<S: Storage> Blockchain<S> {
                         if !nonce_checker.use_nonce(chain_state.get_storage(), tx.get_source(), tx.get_nonce(), highest_topo).await? {
                             warn!("Malicious TX {}, it is a potential double spending with same nonce {}, skipping...", tx_hash, tx.get_nonce());
                             // TX will be orphaned
+                            orphaned_transactions.insert(tx_hash.clone());
                             continue;
                         }
 
@@ -1937,6 +1938,7 @@ impl<S: Storage> Blockchain<S> {
                         if let Err(e) = tx.apply_with_partial_verify(chain_state.as_mut()).await {
                             warn!("Error while executing TX {} with current DAG org: {}", tx_hash, e);
                             // TX may be orphaned if not added again in good order in next blocks
+                            orphaned_transactions.insert(tx_hash.clone());
                             continue;
                         }
 

--- a/xelis_daemon/src/core/blockchain.rs
+++ b/xelis_daemon/src/core/blockchain.rs
@@ -94,7 +94,7 @@ use std::{
     },
     time::Instant
 };
-use tokio::sync::{Mutex, RwLock};
+use tokio::{sync::{Mutex, RwLock}, net::lookup_host};
 use log::{info, error, debug, warn, trace};
 use rand::Rng;
 
@@ -333,7 +333,18 @@ impl<S: Storage> Blockchain<S> {
                         let addr: SocketAddr = match addr.parse() {
                             Ok(addr) => addr,
                             Err(e) => {
-                                error!("Error while parsing priority node address: {}", e);
+                                match lookup_host(&addr).await {
+                                    Ok(it) => {
+                                        info!("Valid host found for {}", addr);
+                                        for addr in it {
+                                            info!("Trying to connect to priority node with IP from DNS resolution: {}", addr);
+                                            p2p.try_to_connect_to_peer(addr, true).await;
+                                        }
+                                    },
+                                    Err(e2) => {
+                                        error!("Error while parsing priority node address: {}, {}", e, e2);
+                                    }
+                                };
                                 continue;
                             }
                         };

--- a/xelis_daemon/src/core/blockchain.rs
+++ b/xelis_daemon/src/core/blockchain.rs
@@ -1769,6 +1769,7 @@ impl<S: Storage> Blockchain<S> {
         debug!("Saving block {} on disk", block_hash);
         // Add block to chain
         storage.save_block(block.clone(), &txs, difficulty, p, block_hash.clone()).await?;
+        storage.add_block_execution_to_order(&block_hash).await?;
 
         // Compute cumulative difficulty for block
         let cumulative_difficulty = {

--- a/xelis_daemon/src/core/error.rs
+++ b/xelis_daemon/src/core/error.rs
@@ -83,6 +83,8 @@ pub enum DiskContext {
     BlocksCount,
     #[error("get accounts count")]
     AccountsCount,
+    #[error("get block execution order count")]
+    BlocksExecutionOrderCount,
     #[error("get top topoheight")]
     TopTopoHeight,
     #[error("get top height")]
@@ -92,6 +94,8 @@ pub enum DiskContext {
     DeleteData,
     #[error("load data")]
     LoadData,
+    #[error("search block position in order")]
+    SearchBlockPositionInOrder
 }
 
 #[repr(usize)]

--- a/xelis_daemon/src/core/storage/mod.rs
+++ b/xelis_daemon/src/core/storage/mod.rs
@@ -20,7 +20,7 @@ use crate::core::error::BlockchainError;
 pub type Tips = HashSet<Hash>;
 
 #[async_trait]
-pub trait Storage: DagOrderProvider + PrunedTopoheightProvider + NonceProvider + AccountProvider + ClientProtocolProvider + BlockDagProvider + MerkleHashProvider + Sync + Send + 'static {
+pub trait Storage: BlockExecutionOrderProvider + DagOrderProvider + PrunedTopoheightProvider + NonceProvider + AccountProvider + ClientProtocolProvider + BlockDagProvider + MerkleHashProvider + Sync + Send + 'static {
     // Is the chain running on mainnet
     fn is_mainnet(&self) -> bool;
 

--- a/xelis_daemon/src/core/storage/providers/block_execution_order.rs
+++ b/xelis_daemon/src/core/storage/providers/block_execution_order.rs
@@ -1,0 +1,67 @@
+use std::sync::atomic::Ordering;
+
+use async_trait::async_trait;
+use indexmap::IndexSet;
+use xelis_common::{crypto::Hash, serializer::Serializer};
+use crate::core::{
+    error::{BlockchainError, DiskContext},
+    storage::SledStorage
+};
+
+// This provider tracks the order in which blocks are added in the chain.
+// This is independant of the DAG order and is used for debug purposes.
+#[async_trait]
+pub trait BlockExecutionOrderProvider {
+    // Get the blocks execution order
+    async fn get_blocks_execution_order(&self, skip: usize, count: usize) -> Result<IndexSet<Hash>, BlockchainError>;
+
+    // Get the position of a block in the execution order
+    async fn get_block_position_in_order(&self, hash: &Hash) -> Result<u64, BlockchainError>;
+
+    // Check if a block is in the execution order
+    async fn has_block_position_in_order(&self, hash: &Hash) -> Result<bool, BlockchainError>;
+
+    // Add a block to the execution order
+    async fn add_block_execution_to_order(&mut self, hash: &Hash) -> Result<(), BlockchainError>;
+
+    // Get the number of blocks executed
+    async fn get_blocks_execution_count(&self) -> u64;
+}
+
+impl SledStorage {
+
+}
+
+#[async_trait]
+impl BlockExecutionOrderProvider for SledStorage {
+    async fn get_blocks_execution_order(&self, skip: usize, count: usize) -> Result<IndexSet<Hash>, BlockchainError> {
+        let order = self.blocks_execution_order.iter()
+            .keys()
+            .skip(skip)
+            .take(count)
+            .map(|x| Ok(Hash::from_bytes(&x?)?))
+            .collect::<Result<_, BlockchainError>>()?;
+
+        Ok(order)
+    }
+
+    async fn get_block_position_in_order(&self, hash: &Hash) -> Result<u64, BlockchainError> {
+        let position = self.load_from_disk(&self.blocks_execution_order, hash.as_bytes(), DiskContext::SearchBlockPositionInOrder)?;
+        Ok(position)
+    }
+
+    async fn has_block_position_in_order(&self, hash: &Hash) -> Result<bool, BlockchainError> {
+        let position = self.blocks_execution_order.contains_key(hash.as_bytes())?;
+        Ok(position)
+    }
+
+    async fn add_block_execution_to_order(&mut self, hash: &Hash) -> Result<(), BlockchainError> {
+        let position = self.blocks_execution_count.fetch_add(1, Ordering::SeqCst);
+        self.blocks_execution_order.insert(hash.to_bytes(), position.to_bytes())?;
+        Ok(())
+    }
+
+    async fn get_blocks_execution_count(&self) -> u64 {
+        self.blocks_execution_count.load(Ordering::SeqCst)
+    }
+}

--- a/xelis_daemon/src/core/storage/providers/mod.rs
+++ b/xelis_daemon/src/core/storage/providers/mod.rs
@@ -11,6 +11,7 @@ mod block;
 mod blockdag;
 mod merkle;
 mod account;
+mod block_execution_order;
 
 pub use asset::AssetProvider;
 pub use blocks_at_height::BlocksAtHeightProvider;
@@ -25,3 +26,4 @@ pub use block::BlockProvider;
 pub use blockdag::BlockDagProvider;
 pub use merkle::MerkleHashProvider;
 pub use account::AccountProvider;
+pub use block_execution_order::BlockExecutionOrderProvider;

--- a/xelis_daemon/src/p2p/error.rs
+++ b/xelis_daemon/src/p2p/error.rs
@@ -153,8 +153,8 @@ pub enum P2pError {
     BoostSyncModeBlockerResponseError(#[from] RecvError),
     #[error("Error while waiting on blocker in boost sync mode")]
     BoostSyncModeBlockerError,
-    #[error("Boost sync mode failed")]
-    BoostSyncModeFailed,
+    #[error("Boost sync mode failed: {}", _0)]
+    BoostSyncModeFailed(Box<P2pError>),
     #[error("Expected a block type")]
     ExpectedBlock,
     #[error("Expected a transaction type")]

--- a/xelis_daemon/src/p2p/mod.rs
+++ b/xelis_daemon/src/p2p/mod.rs
@@ -479,6 +479,9 @@ impl<S: Storage> P2pServer<S> {
         debug!("handle outgoing connections task has exited");
     }
 
+    // This task will handle an incoming connection request
+    // It will verify if we can accept this connection
+    // If we can, we will create a new peer and send it to the listener
     async fn handle_incoming_connection(self: &Arc<Self>, res: io::Result<(TcpStream, SocketAddr)>, thread_pool: &ThreadPool, tx: &Sender<(Peer, Rx)>) -> Result<(), P2pError> {
         let (mut stream, addr) = res?;
 
@@ -517,6 +520,9 @@ impl<S: Storage> P2pServer<S> {
         Ok(())
     }
 
+    // This task will handle all incoming connections requests
+    // Based on the concurrency set, it will create a thread pool to handle requests and wait when
+    // a worker is free to accept a new connection
     async fn handle_incoming_connections(self: Arc<Self>, listener: TcpListener, tx: Sender<(Peer, Rx)>, concurrency: usize) {
         let mut thread_pool = ThreadPool::new(concurrency);
         let mut exit_receiver = self.exit_sender.subscribe();
@@ -1876,30 +1882,64 @@ impl<S: Storage> P2pServer<S> {
             let mut topoheight = common_point.get_topoheight();
             // lets add all blocks ordered hash
             let top_topoheight = self.blockchain.get_topo_height();
-            let stable_height = self.blockchain.get_stable_height();
             // used to detect if we find unstable height for alt tips
-            let mut potential_unstable_height = None;
-            // Search the lowest height
-            let mut lowest_height = self.blockchain.get_height();
+            let mut unstable_height = None;
+            let top_height = self.blockchain.get_height();
             // check to see if we should search for alt tips (and above unstable height)
             let should_search_alt_tips = top_topoheight - topoheight < accepted_response_size as u64;
+            if should_search_alt_tips {
+                debug!("Peer is near to be synced, will send him alt tips blocks");
+                unstable_height = Some(self.blockchain.get_stable_height() + 1);
+            }
+
+            // Search the lowest height
+            let mut lowest_height = top_height;
 
             // complete ChainResponse blocks until we are full or that we reach the top topheight
             while response_blocks.len() < accepted_response_size && topoheight <= top_topoheight {
                 trace!("looking for hash at topoheight {}", topoheight);
                 let hash = storage.get_hash_at_topo_height(topoheight).await?;
-                if should_search_alt_tips && potential_unstable_height.is_none() {
-                    let height = storage.get_height_for_block_hash(&hash).await?;
-                    if height >= stable_height {
-                        debug!("Found unstable height at {}", height);
-                        potential_unstable_height = Some(height);
-                    }
-                }
 
                 // Find the lowest height
                 let height = storage.get_height_for_block_hash(&hash).await?;
                 if height < lowest_height {
                     lowest_height = height;
+                }
+
+                // Sometimes, due to DAG reorg, we need to sync the side block before the main block
+                // This can happen because of the ZK proofs being invalid for the side block
+                // Block must be validated first, then cancelled by DAG internal reorg
+                {
+                    let blocks_at_height = storage.get_blocks_at_height(height).await?;
+                    let has_side = blocks_at_height.len() > 1;
+                    let has_side_next_height = if has_side || topoheight == top_topoheight || height == top_height {
+                        false
+                    } else {
+                        let next_blocks = storage.get_blocks_at_height(height + 1).await?;
+                        next_blocks.len() > 1
+                    };
+
+                    if has_side && !has_side_next_height {
+                        if !self.blockchain.is_side_block_internal(&*storage, &hash, top_topoheight).await? {
+                            let use_blocks_at_height = if let Some(last) = response_blocks.last() {
+                                !self.blockchain.is_side_block_internal(&*storage, last, top_topoheight).await?
+                            } else {
+                                false
+                            };
+    
+                            if use_blocks_at_height {
+                                warn!("Block {} at height {} is not a side block but has side blocks at its own height", hash, height);
+                                for block_hash in blocks_at_height {
+                                    if storage.is_block_topological_ordered(&block_hash).await {
+                                        response_blocks.insert(block_hash);
+                                        if response_blocks.len() >= accepted_response_size {
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
 
                 trace!("for chain request, adding hash {} at topoheight {}", hash, topoheight);
@@ -1909,7 +1949,7 @@ impl<S: Storage> P2pServer<S> {
             lowest_common_height = Some(lowest_height);
 
             // now, lets check if peer is near to be synced, and send him alt tips blocks
-            if let Some(mut height) = potential_unstable_height {
+            if let Some(mut height) = unstable_height {
                 let top_height = self.blockchain.get_height();
                 trace!("unstable height: {}, top height: {}", height, top_height);
                 while height <= top_height && top_blocks.len() < CHAIN_SYNC_TOP_BLOCKS {

--- a/xelis_daemon/src/rpc/rpc.rs
+++ b/xelis_daemon/src/rpc/rpc.rs
@@ -1208,7 +1208,9 @@ async fn validate_address<S: Storage>(_: &Context, body: Value) -> Result<Value,
     let params: ValidateAddressParams = parse_params(body)?;
 
     Ok(json!(ValidateAddressResult {
-        is_valid: params.address.is_normal() || (!params.address.is_normal() && params.allow_integrated),
+        is_valid: (params.address.is_normal() || (!params.address.is_normal() && params.allow_integrated))
+            && params.max_integrated_data_size.and_then(|size| params.address.get_extra_data().map(|data| data.size() <= size))
+            .unwrap_or(true),
         is_integrated: !params.address.is_normal(),
     }))
 }

--- a/xelis_miner/Cargo.toml
+++ b/xelis_miner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xelis_miner"
-version = "1.11.0"
+version = "1.12.0"
 edition = "2021"
 authors = ["Slixe <slixeprivate@gmail.com>"]
 

--- a/xelis_wallet/Cargo.toml
+++ b/xelis_wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xelis_wallet"
-version = "1.11.0"
+version = "1.12.0"
 edition = "2021"
 authors = ["Slixe <slixeprivate@gmail.com>"]
 

--- a/xelis_wallet/src/daemon_api.rs
+++ b/xelis_wallet/src/daemon_api.rs
@@ -34,7 +34,9 @@ use xelis_common::{
         GetMempoolCacheParams,
         GetMempoolCacheResult,
         IsAccountRegisteredParams,
-        TransactionOrphanedEvent
+        TransactionOrphanedEvent,
+        GetTransactionExecutorParams,
+        GetTransactionExecutorResult
     },
     account::VersionedBalance,
     crypto::{
@@ -192,6 +194,13 @@ impl DaemonAPI {
             hash: Cow::Borrowed(hash)
         }).await.context(format!("Error while fetching transaction {}", hash))?;
         Ok(tx)
+    }
+
+    pub async fn get_transaction_executor(&self, hash: &Hash) -> Result<GetTransactionExecutorResult> {
+        let executor = self.client.call_with("get_transaction_executor", &GetTransactionExecutorParams {
+            hash: Cow::Borrowed(hash)
+        }).await?;
+        Ok(executor)
     }
 
     pub async fn submit_transaction(&self, transaction: &Transaction) -> Result<()> {

--- a/xelis_wallet/src/error.rs
+++ b/xelis_wallet/src/error.rs
@@ -2,7 +2,10 @@ use thiserror::Error;
 use chacha20poly1305::Error as CryptoError;
 use super::network_handler::NetworkError;
 use xelis_common::{
-    crypto::Hash, rpc_server::InternalRpcError, transaction::aead::CipherFormatError, utils::{format_coin, format_xelis}
+    crypto::Hash,
+    rpc_server::InternalRpcError,
+    transaction::extra_data::CipherFormatError,
+    utils::{format_coin, format_xelis}
 };
 use anyhow::Error;
 

--- a/xelis_wallet/src/main.rs
+++ b/xelis_wallet/src/main.rs
@@ -463,7 +463,7 @@ async fn prompt_message_builder(prompt: &Prompt, command_manager: Option<&Comman
 // Open a wallet based on the wallet name and its password
 async fn open_wallet(manager: &CommandManager, _: ArgumentManager) -> Result<(), CommandError> {
     let prompt = manager.get_prompt();
-    let name = prompt.read_input("Wallet name: ".into(), false)
+    let name = prompt.read_input("Wallet name: ", false)
         .await.context("Error while reading wallet name")?;
 
     if name.is_empty() {
@@ -477,7 +477,7 @@ async fn open_wallet(manager: &CommandManager, _: ArgumentManager) -> Result<(),
         return Ok(())
     }
 
-    let password = prompt.read_input("Password: ".into(), true)
+    let password = prompt.read_input("Password: ", true)
         .await.context("Error while reading wallet password")?;
 
     let wallet = {
@@ -499,7 +499,7 @@ async fn open_wallet(manager: &CommandManager, _: ArgumentManager) -> Result<(),
 async fn create_wallet(manager: &CommandManager, _: ArgumentManager) -> Result<(), CommandError> {
     let prompt = manager.get_prompt();
 
-    let name = prompt.read_input("Wallet name: ".into(), false)
+    let name = prompt.read_input("Wallet name: ", false)
         .await.context("Error while reading wallet name")?;
 
     if name.is_empty() {
@@ -515,9 +515,9 @@ async fn create_wallet(manager: &CommandManager, _: ArgumentManager) -> Result<(
     }
 
     // ask and verify password
-    let password = prompt.read_input("Password: ".into(), true)
+    let password = prompt.read_input("Password: ", true)
         .await.context("Error while reading password")?;
-    let confirm_password = prompt.read_input("Confirm Password: ".into(), true)
+    let confirm_password = prompt.read_input("Confirm Password: ", true)
         .await.context("Error while reading password")?;
 
     if password != confirm_password {
@@ -551,7 +551,7 @@ async fn create_wallet(manager: &CommandManager, _: ArgumentManager) -> Result<(
 async fn recover_wallet(manager: &CommandManager, _: ArgumentManager) -> Result<(), CommandError> {
     let prompt = manager.get_prompt();
 
-    let seed = prompt.read_input("Seed: ".into(), false)
+    let seed = prompt.read_input("Seed: ", false)
         .await.context("Error while reading seed")?;
 
     let words_count = seed.split_whitespace().count();
@@ -560,7 +560,7 @@ async fn recover_wallet(manager: &CommandManager, _: ArgumentManager) -> Result<
         return Ok(())
     }
 
-    let name = prompt.read_input("Wallet name: ".into(), false)
+    let name = prompt.read_input("Wallet name: ", false)
         .await.context("Error while reading wallet name")?;
 
     if name.is_empty() {
@@ -576,9 +576,9 @@ async fn recover_wallet(manager: &CommandManager, _: ArgumentManager) -> Result<
     }
 
     // ask and verify password
-    let password = prompt.read_input("Password: ".into(), true)
+    let password = prompt.read_input("Password: ", true)
         .await.context("Error while reading password")?;
-    let confirm_password = prompt.read_input("Confirm Password: ".into(), true)
+    let confirm_password = prompt.read_input("Confirm Password: ", true)
         .await.context("Error while reading password")?;
 
     if password != confirm_password {
@@ -891,7 +891,7 @@ async fn seed(manager: &CommandManager, mut arguments: ArgumentManager) -> Resul
     let wallet: &Arc<Wallet> = context.get()?;
     let prompt =  manager.get_prompt();
 
-    let password = prompt.read_input("Password: ".into(), true)
+    let password = prompt.read_input("Password: ", true)
         .await.context("Error while reading password")?;
     // check if password is valid
     wallet.is_valid_password(password).await?;

--- a/xelis_wallet/src/network_handler.rs
+++ b/xelis_wallet/src/network_handler.rs
@@ -28,6 +28,7 @@ use xelis_common::{
         Hash
     },
     serializer::Serializer,
+    transaction::Role,
     utils::{sanitize_daemon_address, spawn_task}
 };
 use crate::{
@@ -269,10 +270,10 @@ impl NetworkHandler {
                         let destination = transfer.destination.to_public_key();
                         if is_owner || destination == *address.get_public_key() {
                             // Get the right handle
-                            let handle = if is_owner {
-                                transfer.sender_handle
+                            let (role, handle) = if is_owner {
+                                (Role::Sender, transfer.sender_handle)
                             } else {
-                                transfer.receiver_handle
+                                (Role::Receiver, transfer.receiver_handle)
                             };
 
                             // Decompress commitment it if possible
@@ -294,7 +295,7 @@ impl NetworkHandler {
                             };
 
                             let extra_data = if let Some(cipher) = transfer.extra_data.into_owned() {
-                                self.wallet.decrypt_extra_data(cipher, &handle).ok()
+                                self.wallet.decrypt_extra_data(cipher, &handle, role).ok()
                             } else {
                                 None
                             };

--- a/xelis_wallet/src/network_handler.rs
+++ b/xelis_wallet/src/network_handler.rs
@@ -523,7 +523,7 @@ impl NetworkHandler {
 
                 synced_topoheight
             } else {
-                0
+                storage.get_synced_topoheight().unwrap_or(0)
             }
         };
 

--- a/xelis_wallet/src/wallet.rs
+++ b/xelis_wallet/src/wallet.rs
@@ -29,21 +29,21 @@ use xelis_common::{
         ecdlp::{self, ECDLPTablesFileView},
         elgamal::{Ciphertext, DecryptHandle, PublicKey as DecompressedPublicKey},
         Address,
+        Hashable,
         KeyPair,
         PublicKey,
-        Signature,
-        Hashable,
+        Signature
     },
     network::Network,
-    serializer::Serializer,
     transaction::{
-        extra_data::{self, AEADCipher},
         builder::{
             FeeBuilder,
             TransactionBuilder,
             TransactionTypeBuilder
         },
+        extra_data::UnknownExtraDataFormat,
         Reference,
+        Role,
         Transaction
     }
 };
@@ -589,11 +589,9 @@ impl Wallet {
     }
 
     // Decrypt the extra data from a transfer
-    pub fn decrypt_extra_data(&self, cipher: AEADCipher, handle: &DecryptHandle) -> Result<DataElement, WalletError> {
+    pub fn decrypt_extra_data(&self, cipher: UnknownExtraDataFormat, handle: &DecryptHandle, role: Role) -> Result<DataElement, WalletError> {
         trace!("decrypt extra data");
-        let key = extra_data::derive_aead_key_from_handle(&self.keypair.get_private_key(), handle);
-        let plaintext = cipher.decrypt_in_place(&key)?;
-        DataElement::from_bytes(&plaintext.0).map_err(|_| WalletError::CiphertextDecode)
+        cipher.decrypt(&self.keypair.get_private_key(), handle, role).map_err(|_| WalletError::CiphertextDecode)
     }
 
     // Create a transaction with the given transaction type and fee

--- a/xelis_wallet/src/wallet.rs
+++ b/xelis_wallet/src/wallet.rs
@@ -37,7 +37,7 @@ use xelis_common::{
     network::Network,
     serializer::Serializer,
     transaction::{
-        aead::{self, AEADCipher},
+        extra_data::{self, AEADCipher},
         builder::{
             FeeBuilder,
             TransactionBuilder,
@@ -591,7 +591,7 @@ impl Wallet {
     // Decrypt the extra data from a transfer
     pub fn decrypt_extra_data(&self, cipher: AEADCipher, handle: &DecryptHandle) -> Result<DataElement, WalletError> {
         trace!("decrypt extra data");
-        let key = aead::derive_aead_key_from_handle(&self.keypair.get_private_key(), handle);
+        let key = extra_data::derive_aead_key_from_handle(&self.keypair.get_private_key(), handle);
         let plaintext = cipher.decrypt_in_place(&key)?;
         DataElement::from_bytes(&plaintext.0).map_err(|_| WalletError::CiphertextDecode)
     }


### PR DESCRIPTION
## Description

Wallet:
- Add a new `extra_data` protocol version

Daemon:
- Track block execution order in a new provider (this is also used for chain sync ordering with side blocks)
- Add DAG cancelled transactions in orphaned list.
- add config `--skip-pow-verification` parameter to skip the PoW verification on new blocks.
- lookup host for priority nodes connection, this support the use of a domain name for peers configuration at launch 
- add rpc method  get_transaction_executor
- fix corruption on pop blocks method

Common:
- API changes in prompt read functions

Wallet:
- Network handler: don't skip txs that aren't executed in the block scanned, search the block executor for it
- Rescan: only starting at requested topoheight

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update

## Which part is impacted ?

  - [X] Daemon
  - [X] Wallet
  - [ ] Miner
  - [X] Misc (documentation, comments, text...)

## Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings