### PR TITLE
all: update argib2 version to 0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,12 +418,13 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "argon2"
-version = "0.4.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4ce4441f99dbd377ca8a8f57b698c44d0d6e712d8329b5040da5a64aa1ce73"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
+ "cpufeatures",
  "password-hash",
 ]
 
@@ -1931,9 +1932,9 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
  "base64ct",
  "rand_core 0.6.4",

--- a/xelis_wallet/Cargo.toml
+++ b/xelis_wallet/Cargo.toml
@@ -11,7 +11,7 @@ xelis_common = { path = "../xelis_common", features = ["json_rpc", "prompt", "cl
 chacha20poly1305 = "0.10.1"
 sled = "0.34.7"
 clap = { version = "4.5.2", features = ["derive"] }
-argon2 = "0.4.1"
+argon2 = "0.5.3"
 lazy_static = "1.4.0"
 crc32fast = "1.3.2"
 actix = "0.13.0"


### PR DESCRIPTION
## Description

I updated argon2 version from 0.4.1 to 0.5.3
of course argon2 0.4.2 is good, but it was released 2 years ago, and its rust dependency is 1.57.
so I updated it to 0.5.3(latest stable version). I think module dependency is very important in development.

## Type of change

Please select the right one.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Which part is impacted ?

  - [ ] Daemon
  - [x] Wallet
  - [ ] Miner
  - [ ] Misc (documentation, comments, text...)

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings