### PR TITLE
Improved web api for miner stats

### DIFF
--- a/xelis_miner/Cargo.toml
+++ b/xelis_miner/Cargo.toml
@@ -21,3 +21,7 @@ tokio = { version = "1.36", features = ["rt"] }
 anyhow = "1"
 fern = { version = "0.6", features = ["colored"] }
 rand = "0.8.4"
+
+[features]
+default = ["api_stats"]
+api_stats = []

--- a/xelis_miner/src/main.rs
+++ b/xelis_miner/src/main.rs
@@ -10,7 +10,7 @@ use std::{
         },
         RwLock
     },
-    thread,
+    thread::{self},
     time::Duration
 };
 use crate::config::DEFAULT_DAEMON_ADDRESS;
@@ -18,13 +18,11 @@ use fern::colors::Color;
 use futures_util::{StreamExt, SinkExt};
 use serde::{Serialize, Deserialize};
 use tokio::{
-    sync::{
+    io::AsyncWriteExt, net::TcpListener, select, sync::{
         broadcast,
         mpsc,
         Mutex
-    },
-    select,
-    time::Instant,
+    }, time::Instant
 };
 use tokio_tungstenite::{
     connect_async,
@@ -91,6 +89,9 @@ pub struct MinerConfig {
     /// Daemon address to connect to for mining
     #[clap(long, default_value_t = String::from(DEFAULT_DAEMON_ADDRESS))]
     daemon_address: String,
+    /// Broadcast address for stats
+    #[clap(long)]
+    broadcast_address: Option<String>,
     /// Set log level
     #[clap(long, value_enum, default_value_t = LogLevel::Info)]
     log_level: LogLevel,
@@ -159,7 +160,9 @@ static CURRENT_TOPO_HEIGHT: AtomicU64 = AtomicU64::new(0);
 static BLOCKS_FOUND: AtomicUsize = AtomicUsize::new(0);
 static BLOCKS_REJECTED: AtomicUsize = AtomicUsize::new(0);
 static HASHRATE_COUNTER: AtomicUsize = AtomicUsize::new(0);
+static HASHRATE: AtomicU64 = AtomicU64::new(0);
 static JOB_ELAPSED: RwLock<Option<Instant>> = RwLock::new(None);
+
 
 lazy_static! {
     static ref HASHRATE_LAST_TIME: Mutex<Instant> = Mutex::new(Instant::now());
@@ -215,6 +218,12 @@ async fn main() -> Result<()> {
 
     // start communication task
     let task = spawn_task("communication", communication_task(config.daemon_address, sender.clone(), block_receiver, address, config.worker));
+    
+    // start stats task
+    let stats = match config.broadcast_address {
+        Some(addr) => Some(spawn_task("broadcast", broadcast_stats_task(addr))),
+        None => None,
+    };
 
     if let Err(e) = run_prompt(prompt).await {
         error!("Error on running prompt: {}", e);
@@ -228,8 +237,46 @@ async fn main() -> Result<()> {
     // stop the communication task
     task.abort();
 
+    // stop the stats broadcast task
+    if let Some(stats_handle) = stats {
+        stats_handle.abort()
+    }
+    
     Ok(())
 }
+
+// This Tokio task will runs indefinitely until the user stops the miner himself.
+// It maintains a http listener and sends stats on connection in json.
+async fn broadcast_stats_task(broadcast_address: String) -> Result<()> {
+    info!("Starting broadcast task");
+    loop {
+        // Start TCP listener
+        let listener = TcpListener::bind(broadcast_address).await?;
+        loop {
+            let (mut socket, _) = listener.accept().await?;
+
+            // Build JSON data
+            let data = serde_json::json!({
+                "accepted": BLOCKS_FOUND,
+                "rejected": BLOCKS_REJECTED,
+                "hashrate": HASHRATE
+            });
+
+            // Build HTTP response
+            let status_line = "HTTP/1.1 200 OK\r\n";
+            let content_type = "Content-Type: application/json\r\n";
+            let contents = data.to_string();
+            let length = contents.len();
+            let response = format!("{status_line}{content_type}Content-Length: {length}\r\n\r\n{contents}");
+
+            // Send HTTP repsonse and close socket
+            tokio::io::AsyncWriteExt::write_all(&mut socket, response.as_bytes())
+                .await?;
+            socket.shutdown().await?;
+        }
+    }
+}
+
 
 // Benchmark the miner with the specified number of threads and iterations
 // It will output the total time, total iterations, time per PoW and hashrate for each number of threads
@@ -504,6 +551,8 @@ async fn run_prompt(prompt: ShareablePrompt) -> Result<()> {
 
             let hashrate = 1000f64 / (last_time.elapsed().as_millis() as f64 / counter as f64);
             *last_time = Instant::now();
+
+            HASHRATE.store(hashrate as u64, Ordering::SeqCst);
 
             prompt.colorize_string(Color::Green, &format!("{}", format_hashrate(hashrate)))
         };


### PR DESCRIPTION
## Description

Main work done in #81

- It is now behind the feature `api_stats` enabled by default.
- Config option is now `api_bind_address`
- `hashrate_formatted` has been added to the response

Thank you

## Type of change

Please select the right one.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Which part is impacted ?

  - [ ] Daemon
  - [ ] Wallet
  - [X] Miner
  - [ ] Misc (documentation, comments, text...)

## Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings