### PR TITLE
Fix typos, grammar, comment clarification and standardization.

### DIFF
--- a/xelis_common/src/account/balance.rs
+++ b/xelis_common/src/account/balance.rs
@@ -8,8 +8,8 @@ use super::CiphertextCache;
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum BalanceType {
-    // Only incoming funds were added
-    // By default, a balance is considered as input
+    // Only incoming funds were added.
+    // By default, a balance is considered as input.
     Input,
     // Only a spending was made from this
     Output,
@@ -42,17 +42,17 @@ impl Serializer for BalanceType {
 
 #[derive(Clone, Deserialize, Serialize, PartialEq, Eq, Debug)]
 pub struct VersionedBalance {
-    // Output balance is used in case of multi TXs not in same block
+    // Output balance is used in case of multi TXs not in same block.
     // If you build several TXs at same time but are not in the same block,
-    // and a incoming tx happen we need to keep track of the output balance
+    // and a incoming tx happen we need to keep track of the output balance.
     output_balance: Option<CiphertextCache>,
-    // Final user balance that contains outputs and inputs balance
-    // This is the balance shown to a user and used to build TXs
+    // Final user balance that contains outputs and inputs balance.
+    // This is the balance shown to a user and used to build TXs.
     final_balance: CiphertextCache,
     // Determine if there was any output made in this version
     balance_type: BalanceType,
-    // Topoheight of the previous versioned balance
-    // If its none, that means it's the first version available
+    // Topoheight of the previous versioned balance.
+    // If its none, that means it's the first version available.
     previous_topoheight: Option<u64>,
 }
 
@@ -211,11 +211,11 @@ impl Serializer for Balance {
 
 #[derive(Debug)]
 pub struct AccountSummary {
-    // last output balance stored on chain
+    // Last output balance stored on chain.
     // It can be None if the account has no output balance
-    // or if the output balance is already in stable_version
+    // or if the output balance is already in stable_version.
     pub output_version: Option<Balance>,
-    // last balance stored on chain below or equal to stable topoheight
+    // Last balance stored on chain below or equal to stable topoheight.
     pub stable_version: Balance 
 }
 

--- a/xelis_common/src/api/daemon.rs
+++ b/xelis_common/src/api/daemon.rs
@@ -134,16 +134,16 @@ pub struct GetBlockTemplateResult {
 
 #[derive(Serialize, Deserialize, PartialEq)]
 pub struct GetMinerWorkResult {
-    // algorithm to use
+    // Algorithm to use
     pub algorithm: Algorithm,
-    // template is miner job in hex format
+    // Template is miner job in hex format
     pub miner_work: String,
-    // block height
+    // Block height
     pub height: u64,
-    // difficulty required for valid block POW
+    // Difficulty required for valid block POW
     pub difficulty: Difficulty,
-    // topoheight of the daemon
-    // this is for visual purposes only
+    // Topoheight of the daemon
+    // This is for visual purposes only
     pub topoheight: u64,
 }
 
@@ -252,7 +252,7 @@ pub struct GetInfoResult {
     pub block_reward: u64,
     pub dev_reward: u64,
     pub miner_reward: u64,
-    // count how many transactions are present in mempool
+    // Count how many transactions are present in mempool
     pub mempool_size: usize,
     // software version on which the daemon is running
     pub version: String,
@@ -262,7 +262,7 @@ pub struct GetInfoResult {
 
 #[derive(Serialize, Deserialize)]
 pub struct SubmitTransactionParams {
-    pub data: String // should be in hex format
+    pub data: String // Should be in hex format
 }
 
 #[derive(Serialize, Deserialize)]
@@ -371,13 +371,13 @@ pub struct GetTransactionsParams {
 
 #[derive(Serialize, Deserialize)]
 pub struct TransactionResponse<'a> {
-    // in which blocks it was included
+    // In which blocks it was included
     pub blocks: Option<HashSet<Hash>>,
-    // in which blocks it was executed
+    // In which blocks it was executed
     pub executed_in_block: Option<Hash>,
-    // if it is in mempool
+    // If it is in mempool
     pub in_mempool: bool,
-    // if its a mempool tx, we add the timestamp when it was added
+    // If its a mempool tx, we add the timestamp when it was added
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub first_seen: Option<TimestampSeconds>,
@@ -470,16 +470,16 @@ pub struct IsTxExecutedInBlockParams<'a> {
 // Struct to define dev fee threshold
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct DevFeeThreshold {
-    // block height to start dev fee
+    // Block height to start dev fee
     pub height: u64,
-    // percentage of dev fee, example 10 = 10%
+    // Percentage of dev fee, example 10 = 10%
     pub fee_percentage: u64
 }
 
 // Struct to define hard fork
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct HardFork {
-    // block height to start hard fork
+    // Block height to start hard fork
     pub height: u64,
     // Block version to use
     pub version: BlockVersion,
@@ -504,11 +504,11 @@ pub struct GetMempoolCacheParams<'a> {
 
 #[derive(Serialize, Deserialize)]
 pub struct GetMempoolCacheResult {
-    // lowest nonce used
+    // Lowest nonce used
     min: u64,
-    // highest nonce used
+    // Highest nonce used
     max: u64,
-    // all txs ordered by nonce
+    // All TXs ordered by nonce
     txs: Vec<Hash>,
     // All "final" cached balances used
     balances: HashMap<Hash, CiphertextCache>
@@ -553,29 +553,29 @@ pub enum ExtractKeyFromAddressResult {
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum NotifyEvent {
-    // When a new block is accepted by chain
-    // it contains NewBlockEvent as value
+    // When a new block is accepted by chain,
+    // it contains NewBlockEvent as value.
     NewBlock,
-    // When a block (already in chain or not) is ordered (new topoheight)
-    // it contains BlockOrderedEvent as value
+    // When a block (already in chain or not) is ordered (new topoheight),
+    // it contains BlockOrderedEvent as value.
     BlockOrdered,
-    // When a block that was ordered is not in the new DAG order
-    // it contains BlockOrphanedEvent that got orphaned
+    // When a block that was ordered is not in the new DAG order,
+    // it contains BlockOrphanedEvent that got orphaned.
     BlockOrphaned,
-    // When stable height has changed (different than the previous one)
-    // it contains StableHeightChangedEvent struct as value
+    // When stable height has changed (different than the previous one),
+    // it contains StableHeightChangedEvent struct as value.
     StableHeightChanged,
-    // When stable topoheight has changed (different than the previous one)
-    // it contains StableTopoHeightChangedEvent struct as value
+    // When stable topoheight has changed (different than the previous one),
+    // it contains StableTopoHeightChangedEvent struct as value.
     StableTopoHeightChanged,
-    // When a transaction that was executed in a block is not reintroduced in mempool
-    // It contains TransactionOrphanedEvent as value
+    // When a transaction that was executed in a block is not reintroduced in mempool,
+    // It contains TransactionOrphanedEvent as value.
     TransactionOrphaned,
-    // When a new transaction is added in mempool
-    // it contains TransactionAddedInMempoolEvent struct as value
+    // When a new transaction is added in mempool,
+    // it contains TransactionAddedInMempoolEvent struct as value.
     TransactionAddedInMempool,
-    // When a transaction has been included in a valid block & executed on chain
-    // it contains TransactionExecutedEvent struct as value
+    // When a transaction has been included in a valid block & executed on chain,
+    // it contains TransactionExecutedEvent struct as value.
     TransactionExecuted,
     // When a registered TX SC Call hash has been executed by chain
     // TODO: Smart Contracts
@@ -583,21 +583,21 @@ pub enum NotifyEvent {
     // When a new asset has been registered
     // TODO: Smart Contracts
     NewAsset,
-    // When a new peer has connected to us
-    // It contains PeerConnectedEvent struct as value
+    // When a new peer has connected to us,
+    // it contains PeerConnectedEvent struct as value.
     PeerConnected,
-    // When a peer has disconnected from us
-    // It contains PeerDisconnectedEvent struct as value
+    // When a peer has disconnected from us,
+    // it contains PeerDisconnectedEvent struct as value.
     PeerDisconnected,
-    // Peer peerlist updated, its all its connected peers
-    // It contains PeerPeerListUpdatedEvent as value
+    // Peer peerlist updated, its all its connected peers,
+    // it contains PeerPeerListUpdatedEvent as value.
     PeerPeerListUpdated,
-    // Peer has been updated through a ping packet
-    // Contains PeerStateUpdatedEvent as value
+    // Peer has been updated through a ping packet,
+    // contains PeerStateUpdatedEvent as value.
     PeerStateUpdated,
     // When a peer of a peer has disconnected
-    // and that he notified us
-    // It contains PeerPeerDisconnectedEvent as value
+    // and he notified us,
+    // it contains PeerPeerDisconnectedEvent as value.
     PeerPeerDisconnected,
 }
 
@@ -607,10 +607,10 @@ pub type NewBlockEvent = BlockResponse;
 // Value of NotifyEvent::BlockOrdered
 #[derive(Serialize, Deserialize)]
 pub struct BlockOrderedEvent<'a> {
-    // block hash in which this event was triggered
+    // Block hash in which this event was triggered
     pub block_hash: Cow<'a, Hash>,
     pub block_type: BlockType,
-    // the new topoheight of the block
+    // The new topoheight of the block
     pub topoheight: u64,
 }
 
@@ -618,7 +618,7 @@ pub struct BlockOrderedEvent<'a> {
 #[derive(Serialize, Deserialize)]
 pub struct BlockOrphanedEvent<'a> {
     pub block_hash: Cow<'a, Hash>,
-    // Tpoheight of the block before being orphaned
+    // Topoheight of the block before being orphaned
     pub old_topoheight: u64
 }
 

--- a/xelis_common/src/api/data.rs
+++ b/xelis_common/src/api/data.rs
@@ -22,7 +22,7 @@ pub enum DataConversionError {
     UnexpectedValue(ValueType),
 }
 
-// All types availables
+// All types available
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Hash, Clone, Copy)]
 pub enum ValueType {
     Bool,
@@ -189,9 +189,9 @@ impl DataElement {
 } 
 
 impl Serializer for DataElement {
-    // Don't do any pre-allocation because of infinite depth
+    // Don't do any pre-allocation because of infinite depth.
     // Otherwise an attacker could generate big depth with high size until max limit
-    // which can create OOM on low devices
+    // which can create OOM on low devices.
     fn read(reader: &mut Reader) -> Result<Self, ReaderError> {
         Ok(match reader.read_u8()? {
             0 => Self::Value(DataValue::read(reader)?),
@@ -225,7 +225,7 @@ impl Serializer for DataElement {
             }
             Self::Array(values) => {
                 writer.write_u8(1);
-                writer.write_u8(values.len() as u8); // we accept up to 255 values
+                writer.write_u8(values.len() as u8); // We accept up to 255 values
                 for value in values {
                     value.write(writer);    
                 }
@@ -273,9 +273,9 @@ pub enum DataValue {
     U64(u64),
     U128(u128),
     Hash(Hash),
-    // This is a specific type for optimized size of binary data
-    // Because above variants rewrite for each element the byte of the element and of each value
-    // It supports up to 65535 bytes (u16::MAX)
+    // This is a specific type for optimized size of binary data.
+    // Because the above variants rewrite for each element the byte of the element and of each value
+    // It supports up to 65535 bytes (u16::MAX).
     Blob(Vec<u8>),
 }
 

--- a/xelis_common/src/api/mod.rs
+++ b/xelis_common/src/api/mod.rs
@@ -116,21 +116,21 @@ impl From<RPCTransactionType<'_>> for TransactionType {
 
 // This is exactly the same as the one in xelis_common/src/transaction/mod.rs
 // We use this one for serde (de)serialization
-// So we have addresses displayed as strings and not Public Key as bytes
-// This is much more easier for developers relying on the API
+// So we have addresses displayed as strings and not Public Key as bytes.
+// This is much more easier for developers relying on the API.
 #[derive(Serialize, Deserialize, Clone)]
 pub struct RPCTransaction<'a> {
     pub hash: Cow<'a, Hash>,
     /// Version of the transaction
     pub version: TxVersion,
-    // Source of the transaction
+    /// Source of the transaction
     pub source: Address,
     /// Type of the transaction
     pub data: RPCTransactionType<'a>,
     /// Fees in XELIS
     pub fee: u64,
-    /// nonce must be equal to the one on chain account
-    /// used to prevent replay attacks and have ordered transactions
+    /// Nonce must be equal to the one on chain account
+    /// Used to prevent replay attacks and have ordered transactions
     pub nonce: u64,
     /// We have one source commitment and equality proof per asset used in the tx.
     pub source_commitments: Cow<'a, Vec<SourceCommitment>>,
@@ -178,12 +178,12 @@ impl<'a> From<RPCTransaction<'a>> for Transaction {
 }
 
 // We create a type above it so for deserialize we can use this type directly
-// and not have to specify the lifetime
+// and not have to specify the lifetime.
 pub type TransactionResponse = RPCTransaction<'static>;
 
 #[derive(Serialize, Deserialize)]
 pub struct SplitAddressParams {
-    // address which must be in integrated form
+    // Address which must be in integrated form
     pub address: Address
 }
 
@@ -203,7 +203,7 @@ fn default_true_value() -> bool {
     true
 }
 
-// same here
+// Same here
 fn default_false_value() -> bool {
     false
 }

--- a/xelis_common/src/api/wallet.rs
+++ b/xelis_common/src/api/wallet.rs
@@ -61,8 +61,8 @@ pub struct GetAssetPrecisionParams<'a> {
 
 #[derive(Serialize, Deserialize)]
 pub struct GetAddressParams {
-    // Data to use for creating an integrated address
-    // Returned address will contains all the data provided here
+    // Data to use for creating an integrated address.
+    // Returned address will contain all the data provided here.
     pub integrated_data: Option<DataElement>
 }
 
@@ -146,21 +146,21 @@ pub struct QueryDBParams {
 #[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum NotifyEvent {
-    // When a new topoheight is detected by wallet
-    // it contains the topoheight (u64) as value
-    // It may be lower than the previous one, based on how the DAG reacts
+    // When a new topoheight is detected by the wallet,
+    // it contains the topoheight (u64) as value.
+    // It may be lower than the previous one, based on how the DAG reacts.
     NewTopoHeight,
-    // When a new asset is added to wallet
-    // Contains a Hash as value
+    // When a new asset is added to the wallet,
+    // Contains a Hash as value.
     NewAsset,
-    // When a new transaction is added to wallet
-    // Contains TransactionEntry struct as value
+    // When a new transaction is added to the wallet,
+    // Contains TransactionEntry struct as value.
     NewTransaction,
-    // When a balance is changed
-    // Contains a BalanceChanged as value
+    // When a balance is changed,
+    // Contains a BalanceChanged as value.
     BalanceChanged,
-    // When a rescan happened on the wallet
-    // Contains a topoheight as value to indicate until which topoheight transactions got deleted
+    // When a rescan happens on the wallet,
+    // Contains a topoheight as value to indicate until which topoheight transactions got deleted.
     Rescan,
     // When network state changed
     Online,
@@ -176,7 +176,7 @@ pub struct TransferOut {
     pub asset: Hash,
     // Plaintext amount
     pub amount: u64,
-    // extra data
+    // Extra data
     pub extra_data: Option<DataElement>
 }
 
@@ -186,7 +186,7 @@ pub struct TransferIn {
     pub asset: Hash,
     // Plaintext amount
     pub amount: u64,
-    // extra data
+    // Extra data
     pub extra_data: Option<DataElement>
 }
 
@@ -217,7 +217,7 @@ pub enum EntryType {
 }
 
 // This struct is used to represent a transaction entry like in wallet
-// But we replace every PublicKey to use Address instead
+// but we replace every PublicKey to use Address instead.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TransactionEntry {
     pub hash: Hash,

--- a/xelis_common/src/block/header.rs
+++ b/xelis_common/src/block/header.rs
@@ -150,9 +150,9 @@ impl BlockHeader {
         self.txs_hashes.len()
     }
 
-    // Build the header work (immutable part in mining process)
-    // This is the part that will be used to compute the header work hash
-    // See get_work_hash function and get_serialized_header for final hash computation
+    // Build the header work (immutable part in mining process).
+    // This is the part that will be used to compute the header work hash.
+    // See get_work_hash function and get_serialized_header for final hash computation.
     pub fn get_work(&self) -> Vec<u8> {
         let mut bytes: Vec<u8> = Vec::with_capacity(HEADER_WORK_SIZE);
 
@@ -166,7 +166,7 @@ impl BlockHeader {
         bytes
     }
 
-    // compute the header work hash (immutable part in mining process)
+    // Compute the header work hash (immutable part in mining process)
     pub fn get_work_hash(&self) -> Hash {
         hash(&self.get_work())
     }
@@ -185,7 +185,7 @@ impl BlockHeader {
         bytes
     }
 
-    // compute the block POW hash
+    // Compute the block POW hash
     pub fn get_pow_hash(&self, algorithm: Algorithm) -> Result<Hash, XelisHashError> {
         pow_hash(&self.get_serialized_header(), algorithm)
     }
@@ -261,7 +261,7 @@ impl Serializer for BlockHeader {
     }
 
     fn size(&self) -> usize {
-        // additional byte for tips count
+        // Additional byte for tips count
         let tips_size = 1 + self.tips.len() * HASH_SIZE;
         // 2 bytes for txs count (u16)
         let txs_size = 2 + self.txs_hashes.len() * HASH_SIZE;
@@ -277,8 +277,8 @@ impl Serializer for BlockHeader {
 }
 
 impl Hashable for BlockHeader {
-    // this function has the same behavior as the get_pow_hash function
-    // but we use a fast algorithm here
+    // This function has the same behavior as the get_pow_hash function
+    // but we use a fast algorithm here.
     fn hash(&self) -> Hash {
         hash(&self.get_serialized_header())
     }

--- a/xelis_common/src/block/miner.rs
+++ b/xelis_common/src/block/miner.rs
@@ -83,18 +83,18 @@ impl fmt::Display for Algorithm {
 // This structure is used by xelis-miner which allow to compute a valid block POW hash
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MinerWork<'a> {
-    header_work_hash: Hash, // include merkle tree of tips, txs, and height (immutable)
-    timestamp: TimestampMillis, // miners can update timestamp to keep it up-to-date
+    header_work_hash: Hash, // Include merkle tree of tips, txs, and height (immutable)
+    timestamp: TimestampMillis, // Miners can update timestamp to keep it up-to-date
     nonce: u64,
     miner: Option<Cow<'a, PublicKey>>,
-    // Extra nonce so miner can write anything
-    // Can also be used to spread more the work job and increase its work capacity
+    // Extra nonce so miner can write anything.
+    // Can also be used to spread more the work job and increase its work capacity.
     extra_nonce: [u8; EXTRA_NONCE_SIZE]
 }
 
-// Worker is used to store the current work and its variant
-// Based on the variant, the worker can compute the POW hash
-// It is used by the miner to efficiently switch context in case of algorithm change
+// Worker is used to store the current work and its variant.
+// Based on the variant, the worker can compute the POW hash.
+// It is used by the miner to efficiently switch context in case of algorithm change.
 pub struct Worker<'a> {
     work: Option<(MinerWork<'a>, [u8; BLOCK_WORK_SIZE])>,
     variant: WorkVariant
@@ -198,8 +198,8 @@ impl<'a> Worker<'a> {
         Ok(hash)
     }
 
-    // Compute the block hash based on the current work
-    // This is used to get the expected block hash
+    // Compute the block hash based on the current work.
+    // This is used to get the expected block hash.
     pub fn get_block_hash(&self) -> Result<Hash, WorkerError> {
         match self.work.as_ref() {
             Some((_, cache)) => Ok(hash(cache)),
@@ -332,8 +332,8 @@ impl<'a> Serializer for MinerWork<'a> {
     }
 }
 
-// no need to override hash() as its already serialized in good format
-// This is used to get the expected block hash
+// No need to override hash() as its already serialized in good format.
+// This is used to get the expected block hash.
 impl Hashable for MinerWork<'_> {}
 
 #[cfg(test)]

--- a/xelis_common/src/block/mod.rs
+++ b/xelis_common/src/block/mod.rs
@@ -14,8 +14,8 @@ pub const EXTRA_NONCE_SIZE: usize = 32;
 pub const HEADER_WORK_SIZE: usize = 73;
 pub const BLOCK_WORK_SIZE: usize = 112; // 32 + 8 + 8 + 32 + 32 = 112
 
-// Get combined hash for tips
-// This is used to get a hash that is unique for a set of tips
+// Get combined hash for tips.
+// This is used to get a hash that is unique for a set of tips.
 pub fn get_combined_hash_for_tips<'a, I: Iterator<Item = &'a Hash>>(tips: I) -> Hash {
     let mut bytes = [0u8; HASH_SIZE];
     for tip in tips {

--- a/xelis_common/src/crypto/address.rs
+++ b/xelis_common/src/crypto/address.rs
@@ -21,8 +21,8 @@ use anyhow::Error;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AddressType {
     Normal,
-    // Data variant allow to integrate data in address for easier communication / data transfered
-    // those data are directly integrated in the data part and can be transfered in the transaction directly
+    // Data variant allows embedding data in an address for easier communication and transfer.
+    // This data is directly integrated and can be transferred within a transaction.
     Data(DataElement)
 }
 
@@ -104,8 +104,8 @@ impl Address {
         self.mainnet
     }
 
-    // Compress the address to a byte array
-    // We don't use Serializer trait to avoid storing mainnet bool
+    // Compress the address to a byte array.
+    // We don't use Serializer trait to avoid storing mainnet bool.
     fn compress(&self) -> Vec<u8> {
         let mut writer = Writer::new();
         self.key.write(&mut writer);
@@ -113,8 +113,8 @@ impl Address {
         writer.bytes()
     }
 
-    // Read the address from a byte array
-    // Hrp validity isn't checked here, it should be done before calling this function
+    // Read the address from a byte array.
+    // Hrp validity isn't checked here, it should be done before calling this function.
     fn decompress(bytes: &[u8], hrp: &str) -> Result<Self, ReaderError> {
         let mut reader = Reader::new(bytes);
         let mainnet = hrp == PREFIX_ADDRESS;
@@ -147,7 +147,7 @@ impl Address {
     // Parse an address from a string (human readable format)
     pub fn from_string(address: &String) -> Result<Self, Error> {
         let (hrp, decoded) = decode(address)?;
-        // check that hrp is valid one
+        // Check that hrp is valid one
         if hrp != PREFIX_ADDRESS && hrp != TESTNET_PREFIX_ADDRESS {
             return Err(Bech32Error::InvalidPrefix(hrp, format!("{} or {}", PREFIX_ADDRESS, TESTNET_PREFIX_ADDRESS)).into())
         }
@@ -155,7 +155,7 @@ impl Address {
         let bits = convert_bits(&decoded, 5, 8, false)?;
         let addr = Address::decompress(&bits, hrp.as_str())?;
 
-        // now check that the hrp decoded is the one for the network state
+        // Now check that the hrp decoded is the one for the network state
         if (addr.is_mainnet() && hrp != PREFIX_ADDRESS) || (!addr.is_mainnet() && hrp != TESTNET_PREFIX_ADDRESS) {
             let expected = if addr.is_mainnet() {
                 PREFIX_ADDRESS

--- a/xelis_common/src/crypto/elgamal/ciphertext.rs
+++ b/xelis_common/src/crypto/elgamal/ciphertext.rs
@@ -4,9 +4,9 @@ use curve25519_dalek::{traits::Identity, RistrettoPoint, Scalar};
 use serde::{Deserialize, Deserializer, Serialize};
 use super::{pedersen::{DecryptHandle, PedersenCommitment}, CompressedCiphertext, CompressedCommitment, CompressedHandle};
 
-// Represents a twisted ElGamal Ciphertext
-// One part is a Pedersen commitment to be bulletproofs compatible
-// The other part is a handle to be used for decryption
+// Represents a twisted ElGamal Ciphertext.
+// One part is a Pedersen commitment to be bulletproofs compatible.
+// The other part is a handle to be used for decryption.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Ciphertext {
     commitment: PedersenCommitment,

--- a/xelis_common/src/crypto/elgamal/key.rs
+++ b/xelis_common/src/crypto/elgamal/key.rs
@@ -43,9 +43,9 @@ impl PublicKey {
         Self(p)
     }
 
-    // Create a new public key from a private key
-    // The public key is H^(-1) * H
-    // Private key must not be zero
+    // Create a new public key from a private key.
+    // The public key is H^(-1) * H.
+    // Private key must not be zero.
     pub fn new(secret: &PrivateKey) -> Self {
         let s = &secret.0;
         assert!(s != &Scalar::ZERO);
@@ -96,8 +96,8 @@ impl PublicKey {
 }
 
 impl PrivateKey {
-    // Create a new private key from a scalar
-    // The scalar must not be zero
+    // Create a new private key from a scalar.
+    // The scalar must not be zero.
     pub fn from_scalar(scalar: Scalar) -> Self {
         assert!(scalar != Scalar::ZERO);
 

--- a/xelis_common/src/crypto/elgamal/mod.rs
+++ b/xelis_common/src/crypto/elgamal/mod.rs
@@ -20,7 +20,7 @@ pub use signature::*;
 pub use curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT as G;
 
 lazy_static! {
-    // base point for encoding the commitments opening
+    // Base point for encoding the commitments opening
     pub static ref H: RistrettoPoint = {
         let mut hasher = sha3::Sha3_512::default();
         hasher.update(RISTRETTO_BASEPOINT_COMPRESSED.as_bytes());

--- a/xelis_common/src/crypto/proofs.rs
+++ b/xelis_common/src/crypto/proofs.rs
@@ -33,8 +33,8 @@ use zeroize::Zeroize;
 pub const BULLET_PROOF_SIZE: usize = 64;
 
 lazy_static! {
-    // Bulletproof generators: party size is max transfers * 2 + 1
-    // * 2 in case each transfer use a unique asset + 1 for xelis asset as fee and + 1 to be a power of 2
+    // Bulletproof generators: party size is max transfers * 2 + 1.
+    // * 2 in case each transfer use a unique asset + 1 for xelis asset as fee and + 1 to be a power of 2.
     pub static ref BP_GENS: BulletproofGens = BulletproofGens::new(BULLET_PROOF_SIZE, MAX_TRANSFER_COUNT * 2 + 2);
     pub static ref PC_GENS: PedersenGens = PedersenGens::default();
 }
@@ -117,7 +117,7 @@ impl BatchCollector {
 
 #[allow(non_snake_case)]
 impl CommitmentEqProof {
-    // warning: caller must make sure not to forget to hash the public key, ciphertext, commitment in the transcript as it is not done here
+    // Warning: Caller must make sure not to forget to hash the public key, ciphertext, commitment in the transcript as it is not done here
     pub fn new(
         source_keypair: &KeyPair,
         source_ciphertext: &Ciphertext,
@@ -127,7 +127,7 @@ impl CommitmentEqProof {
     ) -> Self {
         transcript.equality_proof_domain_separator();
 
-        // extract the relevant scalar and Ristretto points from the inputs
+        // Extract the relevant scalar and Ristretto points from the inputs
         let P_source = source_keypair.get_public_key().as_point();
         let D_source = source_ciphertext.handle().as_point();
 
@@ -135,7 +135,7 @@ impl CommitmentEqProof {
         let x = Scalar::from(amount);
         let r = opening.as_scalar();
 
-        // generate random masking factors that also serves as nonces
+        // Generate random masking factors that also serves as nonces
         let mut y_s = Scalar::random(&mut OsRng);
         let mut y_x = Scalar::random(&mut OsRng);
         let mut y_r = Scalar::random(&mut OsRng);
@@ -145,7 +145,7 @@ impl CommitmentEqProof {
             RistrettoPoint::multiscalar_mul(vec![&y_x, &y_s], vec![&(G), D_source]).compress();
         let Y_2 = RistrettoPoint::multiscalar_mul(vec![&y_x, &y_r], vec![&(G), &(*H)]).compress();
 
-        // record masking factors in the transcript
+        // Record masking factors in the transcript
         transcript.append_point(b"Y_0", &Y_0);
         transcript.append_point(b"Y_1", &Y_1);
         transcript.append_point(b"Y_2", &Y_2);
@@ -153,12 +153,12 @@ impl CommitmentEqProof {
         let c = transcript.challenge_scalar(b"c");
         transcript.challenge_scalar(b"w");
 
-        // compute the masked values
+        // Compute the masked values
         let z_s = &(&c * s) + &y_s;
         let z_x = &(&c * &x) + &y_x;
         let z_r = &(&c * r) + &y_r;
 
-        // zeroize random scalars
+        // Zeroize random scalars
         y_s.zeroize();
         y_x.zeroize();
         y_r.zeroize();
@@ -183,13 +183,13 @@ impl CommitmentEqProof {
     ) -> Result<(), ProofVerificationError> {
         transcript.equality_proof_domain_separator();
 
-        // extract the relevant scalar and Ristretto points from the inputs
+        // Extract the relevant scalar and Ristretto points from the inputs
         let P_source = source_pubkey.as_point();
         let C_source = source_ciphertext.commitment().as_point();
         let D_source = source_ciphertext.handle().as_point();
         let C_destination = destination_commitment.as_point();
 
-        // include Y_0, Y_1, Y_2 to transcript and extract challenges
+        // Include Y_0, Y_1, Y_2 to transcript and extract challenges
         transcript.validate_and_append_point(b"Y_0", &self.Y_0)?;
         transcript.validate_and_append_point(b"Y_1", &self.Y_1)?;
         transcript.validate_and_append_point(b"Y_2", &self.Y_2)?;
@@ -201,7 +201,7 @@ impl CommitmentEqProof {
         let w_negated = -&w;
         let ww_negated = -&ww;
 
-        // check that the required algebraic condition holds
+        // Check that the required algebraic condition holds
         let Y_0 = self
             .Y_0
             .decompress()
@@ -284,7 +284,7 @@ impl CiphertextValidityProof {
         let c = transcript.challenge_scalar(b"c");
         transcript.challenge_scalar(b"w");
 
-        // masked message and opening
+        // Masked message and opening
         let z_r = &(&c * r) + &y_r;
         let z_x = &(&c * &x) + &y_x;
 

--- a/xelis_common/src/crypto/transcript.rs
+++ b/xelis_common/src/crypto/transcript.rs
@@ -74,7 +74,7 @@ impl ProtocolTranscript for Transcript {
         }
     }
 
-    // domain separators
+    // Domain separators
 
     fn new_commitment_eq_proof_domain_separator(&mut self) {
         self.append_message(b"dom-sep", b"new-commitment-proof");

--- a/xelis_common/src/difficulty.rs
+++ b/xelis_common/src/difficulty.rs
@@ -3,11 +3,11 @@ use primitive_types::U256;
 use thiserror::Error;
 
 // This type is used to easily switch between u64 and u128 as example
-// And its easier to see where we use the block difficulty
-// Difficulty is a value that represents the amount of work required to mine a block
-// On XELIS, each difficulty point is a hash per second
+// and its easier to see where we use the block difficulty.
+// Difficulty is a value that represents the amount of work required to mine a block.
+// On XELIS, each difficulty point is a hash per second.
 pub type Difficulty = VarUint;
-// Cumulative difficulty is the sum of all difficulties of all blocks in the chain
+// Cumulative difficulty is the sum of all difficulties of all blocks in the chain.
 // It is used to determine which branch is the main chain in BlockDAG merging.
 pub type CumulativeDifficulty = VarUint;
 
@@ -19,15 +19,15 @@ pub enum DifficultyError {
     ErrorOnConversionBigUint
 }
 
-// Verify the validity of a block difficulty against the current network difficulty
-// All operations are done on U256 to avoid overflow
+// Verify the validity of a block difficulty against the current network difficulty.
+// All operations are done on U256 to avoid overflow.
 pub fn check_difficulty(hash: &Hash, difficulty: &Difficulty) -> Result<bool, DifficultyError> {
     let target = compute_difficulty_target(difficulty)?;
     Ok(check_difficulty_against_target(hash, &target))
 }
 
-// Compute the difficulty target from the difficulty value
-// This can be used to keep the target in cache instead of recomputing it each time
+// Compute the difficulty target from the difficulty value.
+// This can be used to keep the target in cache instead of recomputing it each time.
 pub fn compute_difficulty_target(difficulty: &Difficulty) -> Result<U256, DifficultyError> {
     let diff = difficulty.as_ref();
     if diff.is_zero() {
@@ -43,8 +43,8 @@ pub fn check_difficulty_against_target(hash: &Hash, target: &U256) -> bool {
     hash_work <= *target
 }
 
-// Convert a hash to a difficulty value
-// This is only used by miner
+// Convert a hash to a difficulty value.
+// This is only used by miner.
 #[inline(always)]
 pub fn difficulty_from_hash(hash: &Hash) -> Difficulty {
     (U256::max_value() / U256::from_big_endian(hash.as_bytes())).into()

--- a/xelis_common/src/json_rpc/websocket.rs
+++ b/xelis_common/src/json_rpc/websocket.rs
@@ -50,10 +50,10 @@ impl<T: DeserializeOwned> EventReceiver<T> {
         }
     }
 
-    // Get the next event
-    // if we lagged behind, we will catch up
+    // Get the next event.
+    // If we lagged behind, we will catch up.
     // If you don't want to miss any event, you should create a queue to store them
-    // or an unbounded channel
+    // or an unbounded channel.
     pub async fn next(&mut self) -> Result<T, Error> {
         let mut res = self.inner.recv().await;
         // If we lagged behind, we need to catch up
@@ -72,8 +72,8 @@ impl<T: DeserializeOwned> EventReceiver<T> {
     }
 }
 
-// It is around a Arc to be shareable easily
-// it has a tokio task running in background to handle all incoming messages
+// It is around an Arc to be shareable easily.
+// It has a tokio task running in background to handle all incoming messages.
 pub type WebSocketJsonRPCClient<E> = Arc<WebSocketJsonRPCClientImpl<E>>;
 
 enum InternalMessage {
@@ -81,8 +81,8 @@ enum InternalMessage {
     Close,
 }
 
-// A JSON-RPC Client over WebSocket protocol to support events
-// It can be used in multi-thread safely because each request/response are linked using the id attribute.
+// A JSON-RPC Client over WebSocket protocol to support events.
+// It can be used in multi-thread safely because each request/response are linked using the id attribute..
 pub struct WebSocketJsonRPCClientImpl<E: Serialize + Hash + Eq + Send + Sync + Clone + 'static> {
     sender: Mutex<mpsc::Sender<InternalMessage>>,
     // This is the ID for the next request
@@ -97,9 +97,9 @@ pub struct WebSocketJsonRPCClientImpl<E: Serialize + Hash + Eq + Send + Sync + C
     events_to_id: Mutex<HashMap<E, usize>>,
     // websocket server address
     target: String,
-    // delay auto reconnect duration
+    // Delay auto reconnect duration
     delay_auto_reconnect: Mutex<Option<Duration>>,
-    // is the client online
+    // Is the client online
     online: AtomicBool,
     // This channel is called when the connection is lost
     offline_channel: Mutex<Option<broadcast::Sender<()>>>,
@@ -209,7 +209,7 @@ impl<E: Serialize + Hash + Eq + Send + Sync + Clone + std::fmt::Debug + 'static>
         self.online.load(Ordering::SeqCst)
     }
 
-    // resubscribe to all events because of a reconnection
+    // Resubscribe to all events because of a reconnection
     async fn resubscribe_events(self: Arc<Self>) -> Result<(), JsonRPCError> {
         let events = {
             let events = self.events_to_id.lock().await;
@@ -354,7 +354,7 @@ impl<E: Serialize + Hash + Eq + Send + Sync + Clone + std::fmt::Debug + 'static>
 
                 zelf.set_online(false).await;
 
-                // retry to connect until we are online or that it got disabled
+                // Retry to connect until we are online or that it got disabled
                 while let Some(auto_reconnect) = { zelf.delay_auto_reconnect.lock().await.as_ref().cloned() } {
                     debug!("Reconnecting to the server in {} seconds...", auto_reconnect.as_secs());
                     sleep(auto_reconnect).await;
@@ -415,7 +415,7 @@ impl<E: Serialize + Hash + Eq + Send + Sync + Clone + std::fmt::Debug + 'static>
                         Message::Text(text) => {
                             let response: JsonRPCResponse = serde_json::from_str(&text)?;
                             if let Some(id) = response.id {
-                                // send the response to the requester if it matches the ID
+                                // Send the response to the requester if it matches the ID
                                 {
                                     let mut requests = self.requests.lock().await;
                                     if let Some(sender) = requests.remove(&id) {
@@ -466,8 +466,8 @@ impl<E: Serialize + Hash + Eq + Send + Sync + Clone + std::fmt::Debug + 'static>
         events.contains_key(&event)
     }
 
-    // Subscribe to an event
-    // Capacity represents the number of events that can be stored in the channel
+    // Subscribe to an event.
+    // Capacity represents the number of events that can be stored in the channel.
     pub async fn subscribe_event<T: DeserializeOwned>(&self, event: E, capacity: usize) -> JsonRPCResult<EventReceiver<T>> {
         // Returns a Receiver for this event if already registered
         {
@@ -515,7 +515,7 @@ impl<E: Serialize + Hash + Eq + Send + Sync + Clone + std::fmt::Debug + 'static>
         // Send the unsubscribe rpc method
         self.send::<E, bool>("unsubscribe", None, event).await?;
 
-        // delete it from events list
+        // Delete it from events list
         {
             let mut handlers = self.handler_by_id.lock().await;
             handlers.remove(&id);

--- a/xelis_common/src/prompt/command.rs
+++ b/xelis_common/src/prompt/command.rs
@@ -14,7 +14,7 @@ pub enum CommandError {
     #[error("Command was not found")]
     CommandNotFound,
     #[error("Expected required argument {}", _0)]
-    ExpectedRequiredArg(String), // arg name
+    ExpectedRequiredArg(String), // Arg name
     #[error("Too many arguments")]
     TooManyArguments,
     #[error(transparent)]
@@ -232,7 +232,7 @@ impl CommandManager {
             arguments.insert(arg.get_name().clone(), arg.get_type().to_value(arg_value)?);
         }
 
-        // include all options args available
+        // Include all options args available
         for optional_arg in command.get_optional_args() {
             if let Some(arg_value) = command_split.next() {
                 arguments.insert(optional_arg.get_name().clone(), optional_arg.get_type().to_value(arg_value)?);

--- a/xelis_common/src/prompt/terminal.rs
+++ b/xelis_common/src/prompt/terminal.rs
@@ -3,7 +3,7 @@ use std::mem;
 use indexmap::IndexSet;
 
 pub struct Terminal {
-    // all commands used during its running time
+    // All commands used during its running time
     history: IndexSet<String>,
     // Index when navigating in the history
     history_index: Option<usize>,
@@ -61,7 +61,7 @@ impl Terminal {
         }
     }
 
-    // advance by one if possible the cursor
+    // Advance by one if possible the cursor
     pub fn next_cursor(&mut self) {
         let next = self.buffer.len() > self.cursor_index;
         if next {

--- a/xelis_common/src/queue.rs
+++ b/xelis_common/src/queue.rs
@@ -1,10 +1,10 @@
 use std::{hash::Hash, collections::{VecDeque, HashSet}, fmt::Debug, sync::Arc};
 
-// A queue that allows for O(1) lookup of elements
-// The queue is backed by a VecDeque and a HashSet
-// The HashSet is used to check if an element is already in the queue
-// The VecDeque is used to keep track of the order of the elements
-// This can be shared between threads
+// A queue that allows for O(1) lookup of elements.
+// The queue is backed by a VecDeque and a HashSet.
+// The HashSet is used to check if an element is already in the queue.
+// The VecDeque is used to keep track of the order of the elements.
+// This can be shared between threads.
 pub struct Queue<K: Hash + Eq + Debug, V> {
     keys: HashSet<Arc<K>>,
     order: VecDeque<(Arc<K>, V)>
@@ -18,8 +18,8 @@ impl<K: Hash + Eq + Debug, V> Queue<K, V> {
         }
     }
 
-    // Pushes a new element to the back of the queue
-    // Returns true if the element was added, false if it already exists
+    // Pushes a new element to the back of the queue.
+    // Returns true if the element was added, false if it already exists.
     pub fn push(&mut self, key: K, value: V) -> bool {
         if self.keys.contains(&key) {
             return false;

--- a/xelis_common/src/rpc_server/mod.rs
+++ b/xelis_common/src/rpc_server/mod.rs
@@ -48,7 +48,7 @@ impl<'a> RpcResponse<'a> {
     }
 }
 
-// trait to retrieve easily a JSON RPC handler for registered route
+// Trait to retrieve easily a JSON RPC handler for registered route
 pub trait RPCServerHandler<T: Send + Clone> {
     fn get_rpc_handler(&self) -> &RPCHandler<T>;
 }
@@ -63,7 +63,7 @@ where
     Ok(HttpResponse::Ok().json(result))
 }
 
-// trait to retrieve easily a websocket handler for registered route
+// Trait to retrieve easily a websocket handler for registered route
 pub trait WebSocketServerHandler<H: WebSocketHandler> {
     fn get_websocket(&self) -> &WebSocketServerShared<H>;
 }

--- a/xelis_common/src/rpc_server/rpc_handler.rs
+++ b/xelis_common/src/rpc_server/rpc_handler.rs
@@ -9,7 +9,7 @@ use log::{error, trace};
 pub type Handler = fn(&'_ Context, Value) -> Pin<Box<dyn Future<Output = Result<Value, InternalRpcError>> + Send + '_>>;
 
 pub struct RPCHandler<T: Send + Clone + 'static> {
-    methods: HashMap<String, Handler>, // all RPC methods registered
+    methods: HashMap<String, Handler>, // All RPC methods registered
     data: T
 }
 
@@ -96,7 +96,7 @@ where
         })
     }
 
-    // register a new RPC method handler
+    // Register a new RPC method handler
     pub fn register_method(&mut self, name: &str, handler: Handler) {
         if self.methods.insert(name.into(), handler).is_some() {
             error!("The method '{}' was already registered !", name);

--- a/xelis_common/src/rpc_server/websocket/handler.rs
+++ b/xelis_common/src/rpc_server/websocket/handler.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 use super::{WebSocketSessionShared, WebSocketHandler};
 
-// generic websocket handler supporting event subscriptions 
+// Generic websocket handler supporting event subscriptions 
 pub struct EventWebSocketHandler<T: Sync + Send + Clone + 'static, E: Serialize + DeserializeOwned + Sync + Send + Eq + Hash + Clone + 'static> {
     events: RwLock<HashMap<WebSocketSessionShared<Self>, HashMap<E, Option<Id>>>>,
     handler: RPCHandler<T>

--- a/xelis_common/src/serializer/reader.rs
+++ b/xelis_common/src/serializer/reader.rs
@@ -24,8 +24,8 @@ pub enum ReaderError {
 // Reader help us to read safely from bytes
 // Mostly used when de-serializing an object from Serializer trait 
 pub struct Reader<'a> {
-    bytes: &'a[u8], // bytes to read
-    total: usize // total read bytes
+    bytes: &'a[u8], // Bytes to read
+    total: usize // Total read bytes
 }
 
 impl<'a> Reader<'a> {

--- a/xelis_common/src/time.rs
+++ b/xelis_common/src/time.rs
@@ -15,7 +15,7 @@ pub fn get_current_time() -> Duration {
     time
 }
 
-// return timestamp in seconds
+// Return timestamp in seconds
 pub fn get_current_time_in_seconds() -> TimestampSeconds {
     get_current_time().as_secs()
 }

--- a/xelis_common/src/tokio/mod.rs
+++ b/xelis_common/src/tokio/mod.rs
@@ -17,8 +17,8 @@ pub use tokio_with_wasm::*;
 pub use tokio::*;
 
 
-// Spawn a new task with a name
-// If the tokio_unstable feature is enabled, the task will be named
+// Spawn a new task with a name.
+// If the tokio_unstable feature is enabled, the task will be named.
 #[inline(always)]
 #[cfg(not(all(
     target_arch = "wasm32",
@@ -43,8 +43,8 @@ where
     }
 }
 
-// Spawn a new task with a name
-// Send trait is not required for wasm32
+// Spawn a new task with a name.
+// Send trait is not required for wasm32.
 #[cfg(all(
     target_arch = "wasm32",
     target_vendor = "unknown",

--- a/xelis_common/src/transaction/builder.rs
+++ b/xelis_common/src/transaction/builder.rs
@@ -74,7 +74,7 @@ pub enum GenerationError<T> {
     EncryptedExtraDataTooLarge(usize, usize),
     #[error("Address is not on the same network as us")]
     InvalidNetwork,
-    #[error("Extra data was provied with an integrated address")]
+    #[error("Extra data was provided with an integrated address")]
     ExtraDataAndIntegratedAddress,
     #[error("Proof generation error: {0}")]
     Proof(#[from] ProofGenerationError),
@@ -83,9 +83,9 @@ pub enum GenerationError<T> {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum FeeBuilder {
-    // calculate tx fees based on its size and multiply by this value
+    // Calculate tx fees based on its size and multiply by this value
     Multiplier(f64),
-    Value(u64) // set a direct value of how much fees you want to pay
+    Value(u64) // Set a direct value of how much fees you want to pay
 }
 
 impl Default for FeeBuilder {

--- a/xelis_common/src/transaction/extra_data.rs
+++ b/xelis_common/src/transaction/extra_data.rs
@@ -43,11 +43,11 @@ pub const TAG_SIZE: usize = 16;
 
 // This error is thrown when the ciphertext is not in the expected format.
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
-#[error("malformated ciphertext")]
+#[error("malformatted ciphertext")]
 pub struct CipherFormatError;
 
 /// Every transfer has its associated secret key, derived from the shared secret.
-/// We never use a key twice, then. We can reuse the same nonce everytime.
+/// We never use a key twice, then. We can reuse the same nonce every time.
 const NONCE: &[u8; 12] = b"xelis-crypto";
 
 /// This is the encrypted data, which is the result of the encryption process.
@@ -77,7 +77,7 @@ pub struct UnknownExtraDataFormat(pub Vec<u8>);
 
 // New version of Extra Data due to the issue of commitment randomness reuse
 // https://gist.github.com/kayabaNerve/b754e9ed9fa4cc2c607f38a83aa3df2a
-// We create a new opening to be independant of the amount opening.
+// We create a new opening to be independent of the amount opening.
 // This is more secure and prevent bruteforce attack from the above link.
 // We need to store 64 bytes more than previous version due to the exclusive handles created.
 pub struct ExtraData {
@@ -280,7 +280,7 @@ impl PlaintextData {
     pub fn encrypt_in_place_with_aead(mut self, key: &SharedKey) -> AEADCipher {
         let c = ChaCha20Poly1305::new(&key);
         c.encrypt_in_place(NONCE.into(), &[], &mut self.0)
-            .expect("unreachable (unsufficient capacity on a vec)");
+            .expect("unreachable (insufficient capacity on a vec)");
 
         AEADCipher(self.0)
     }

--- a/xelis_common/src/transaction/mod.rs
+++ b/xelis_common/src/transaction/mod.rs
@@ -64,7 +64,7 @@ pub struct SourceCommitment {
 pub struct TransferPayload {
     asset: Hash,
     destination: CompressedPublicKey,
-    // we can put whatever we want up to EXTRA_DATA_LIMIT_SIZE bytes
+    // We can put whatever we want up to EXTRA_DATA_LIMIT_SIZE bytes
     extra_data: Option<UnknownExtraDataFormat>,
     /// Represents the ciphertext along with `sender_handle` and `receiver_handle`.
     /// The opening is reused for both of the sender and receiver commitments.
@@ -81,7 +81,7 @@ pub struct BurnPayload {
     pub amount: u64
 }
 
-// this enum represent all types of transaction available on XELIS Network
+// This enum represent all types of transaction available on XELIS Network
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum TransactionType {
@@ -100,8 +100,8 @@ pub struct Transaction {
     data: TransactionType,
     /// Fees in XELIS
     fee: u64,
-    /// nonce must be equal to the one on chain account
-    /// used to prevent replay attacks and have ordered transactions
+    /// Nonce must be equal to the one on chain account
+    /// Used to prevent replay attacks and have ordered transactions
     nonce: u64,
     /// We have one source commitment and equality proof per asset used in the tx.
     source_commitments: Vec<SourceCommitment>,

--- a/xelis_common/src/transaction/verify.rs
+++ b/xelis_common/src/transaction/verify.rs
@@ -147,7 +147,7 @@ impl DecompressedTransferCt {
 
 impl Transaction {
     /// Get the new output ciphertext
-    // This is used to substract the amount from the sender's balance
+    // This is used to subtract the amount from the sender's balance
     fn get_sender_output_ct(
         &self,
         asset: &Hash,
@@ -229,8 +229,8 @@ impl Transaction {
         }
     }
 
-    // internal, does not verify the range proof
-    // returns (transcript, commitments for range proof)
+    // Internal, does not verify the range proof
+    // returns (transcript, commitments for range proof).
     async fn pre_verify<'a, E, B: BlockchainVerificationState<'a, E>>(
         &'a self,
         state: &mut B,
@@ -282,7 +282,7 @@ impl Transaction {
                 }
             }
 
-            // TODO: this is temporary until the hardfork has passed
+            // TODO: This is temporary until the hardfork has passed
             let max_size = if state.get_block_version() == BlockVersion::V0 {
                 EXTRA_DATA_LIMIT_SIZE
             } else {
@@ -583,9 +583,9 @@ impl Transaction {
         Ok(())
     }
 
-    /// Verify only that the final sender balance is the expected one for each commitment
-    /// Then apply ciphertexts to the state
-    /// Checks done are: commitment eq proofs only
+    /// Verify only that the final sender balance is the expected one for each commitment.
+    /// Then apply ciphertexts to the state.
+    /// Checks done are: commitment eq proofs only.
     pub async fn apply_with_partial_verify<'a, E, B: BlockchainVerificationState<'a, E>>(&'a self, state: &mut B) -> Result<(), VerificationError<E>> {
         trace!("apply with partial verify");
         let mut sigma_batch_collector = BatchCollector::default();

--- a/xelis_common/src/utils.rs
+++ b/xelis_common/src/utils.rs
@@ -45,14 +45,14 @@ pub fn from_coin(value: impl Into<String>, coin_decimals: u8) -> Option<u64> {
     Some(value * 10u64.pow(coin_decimals as u32) + decimals_value)
 }
 
-// return the fee for a transaction based on its size in bytes
-// the fee is calculated in atomic units for XEL
-// Sending to a newly created address will increase the fee
-// Each transfers output will also increase the fee
+// Return the fee for a transaction based on its size in bytes.
+// The fee is calculated in atomic units for XEL.
+// Sending to a newly created address will increase the fee.
+// Each transfers output will also increase the fee.
 pub fn calculate_tx_fee(tx_size: usize, output_count: usize, new_addresses: usize) -> u64 {
     let mut size_in_kb = tx_size as u64 / 1024;
 
-    if tx_size % 1024 != 0 { // we consume a full kb for fee
+    if tx_size % 1024 != 0 { // We consume a full kb for fee
         size_in_kb += 1;
     }
 
@@ -98,8 +98,8 @@ pub fn format_difficulty(mut difficulty: Difficulty) -> String {
     return format!("{}{}{}", difficulty, left_str, DIFFICULTY_FORMATS[count]);
 }
 
-// Sanitize a daemon address to make sure it's a valid websocket address
-// By default, will use ws:// if no protocol is specified
+// Sanitize a daemon address to make sure it's a valid websocket address.
+// By default, will use ws:// if no protocol is specified.
 pub fn sanitize_daemon_address(target: &str) -> String {
     let mut target = target.to_lowercase();
     if target.starts_with("https://") {

--- a/xelis_common/src/varuint.rs
+++ b/xelis_common/src/varuint.rs
@@ -7,11 +7,11 @@ use primitive_types::U256;
 use serde::{Deserialize, Serialize};
 use crate::serializer::{Reader, ReaderError, Serializer, Writer};
 
-// This is like a variable length integer but up to U256
-// It is mostly used to save difficulty and cumulative difficulty on disk
-// In memory, it keeps using U256 (32 bytes)
-// On disk it can be as small as 1 byte and as big as 33 bytes
-// First byte written is the VarUint length (1 to 32)
+// This is like a variable length integer but up to U256.
+// It is mostly used to save difficulty and cumulative difficulty on disk.
+// In memory, it keeps using U256 (32 bytes).
+// On disk it can be as small as 1 byte and as big as 33 bytes.
+// First byte written is the VarUint length (1 to 32).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub struct VarUint(U256);
 
@@ -85,7 +85,7 @@ impl Serializer for VarUint {
         Ok(Self(U256::from_big_endian(&buffer)))
     }
 
-    // no fast size impl as it's same as writing it
+    // No fast size impl as it's same as writing it
 }
 
 impl AsRef<U256> for VarUint {

--- a/xelis_daemon/src/config.rs
+++ b/xelis_daemon/src/config.rs
@@ -13,11 +13,11 @@ use xelis_common::{
     time::TimestampSeconds
 };
 
-// In case of potential forks, have a unique network id to not connect to others compatible chains
+// In case of potential forks, have a unique network id to not connect to other compatible chains
 pub const NETWORK_ID_SIZE: usize = 16;
 pub const NETWORK_ID: [u8; NETWORK_ID_SIZE] = [0x73, 0x6c, 0x69, 0x78, 0x65, 0x5f, 0x78, 0x65, 0x6c, 0x69, 0x73, 0x5f, 0x62, 0x6c, 0x6f, 0x63];
 
-// bind addresses
+// Bind addresses
 pub const DEFAULT_P2P_BIND_ADDRESS: &str = "0.0.0.0:2125";
 pub const DEFAULT_RPC_BIND_ADDRESS: &str = "0.0.0.0:8080";
 
@@ -25,36 +25,37 @@ pub const DEFAULT_RPC_BIND_ADDRESS: &str = "0.0.0.0:8080";
 pub const DEFAULT_CACHE_SIZE: usize = 1024;
 
 // Block rules
-// Millis per second, it is used to prevent having random 1000 values anywhere
+// Millis per second, it is used to prevent having random 1000 values anywhere.
 pub const MILLIS_PER_SECOND: u64 = 1000;
 // Block Time in milliseconds
 pub const BLOCK_TIME_MILLIS: u64 = 15 * MILLIS_PER_SECOND; // 15s block time
 // Minimum difficulty (each difficulty point is in H/s)
 // Current: BLOCK TIME in millis * 20 = 20 KH/s minimum
-// This is to prevent spamming the network with low difficulty blocks
-// This is active only on mainnet mode
+// This is to prevent spamming the network with low difficulty blocks.
+// This is active only on mainnet mode.
 pub const MAINNET_MINIMUM_DIFFICULTY: Difficulty = Difficulty::from_u64(BLOCK_TIME_MILLIS * 20);
 // Testnet & Devnet minimum difficulty
 pub const OTHER_MINIMUM_DIFFICULTY: Difficulty = Difficulty::from_u64(BLOCK_TIME_MILLIS * 2);
 // This is also used as testnet and devnet minimum difficulty
 pub const GENESIS_BLOCK_DIFFICULTY: Difficulty = Difficulty::from_u64(1);
-// 2 seconds maximum in future (prevent any attack on reducing difficulty but keep margin for unsynced devices)
+// Maximum timestamp allowed in the future is 2 seconds.
+// This helps prevent attacks that exploit difficulty reduction while allowing a margin for unsynced devices.
 pub const TIMESTAMP_IN_FUTURE_LIMIT: TimestampSeconds = 2 * 1000;
 
-// keep at least last N blocks until top topoheight when pruning the chain
-// WARNING: This must be at least 50 blocks for difficulty adjustement
+// Keep at least last N blocks until top topoheight when pruning the chain.
+// WARNING: This must be at least 50 blocks for difficulty adjustment.
 pub const PRUNE_SAFETY_LIMIT: u64 = STABLE_LIMIT * 10;
 
 // BlockDAG rules
 pub const STABLE_LIMIT: u64 = 8; // in how many height we consider the block stable
 
 // Emission rules
-// 15% (6 months), 10% (6 months), 5% per block going to dev address
+// 15% (6 months), 10% (6 months), 5% per block going to dev address.
 // NOTE: The explained emission above was the expected one
-// But due to a bug in the function to calculate the dev fee reward,
+// but due to a bug in the function to calculate the dev fee reward,
 // the actual emission was directly set to 10% per block
-// New emission rules are: 10% during 1.5 years, then 5% for the rest
-// This is the same for the project but reduce a bit the mining cost as they earn 5% more
+// New emission rules are: 10% during 1.5 years, then 5% for the rest.
+// This is functionally the same for the project but slightly reduce the mining cost as they receive 5% more.
 pub const DEV_FEES: [DevFeeThreshold; 2] = [
     // Activated for 3M blocks
     DevFeeThreshold {
@@ -69,29 +70,29 @@ pub const DEV_FEES: [DevFeeThreshold; 2] = [
         fee_percentage: 5
     }
 ];
-// only 30% of reward for side block
+// Only 30% of reward for side block.
 // This is to prevent spamming side blocks
-// and also give rewards for miners with valid work on main chain
+// and also give rewards for miners with valid work on main chain.
 pub const SIDE_BLOCK_REWARD_PERCENT: u64 = 30;
-// maximum 3 blocks for side block reward
-// Each side block reward will be divided by the number of side blocks * 2
+// Maximum 3 blocks for side block reward.
+// Each side block reward will be divided by the number of side blocks * 2.
 // With a configuration of 3 blocks, we have the following percents:
 // 1 block: 30%
 // 2 blocks: 15%
 // 3 blocks: 7%
 // 4 blocks: minimum percentage set below
 pub const SIDE_BLOCK_REWARD_MAX_BLOCKS: u64 = 3;
-// minimum 5% of block reward for side block
-// This is the minimum given for all others valid side blocks
+// Minimum 5% of block reward for side block.
+// This is the minimum given for all others valid side blocks.
 pub const SIDE_BLOCK_REWARD_MIN_PERCENT: u64 = 5;
-// Emission speed factor for the emission curve
-// It is used to calculate based on the supply the block reward
+// Emission speed factor for the emission curve.
+// It is used to calculate based on the supply the block reward.
 pub const EMISSION_SPEED_FACTOR: u64 = 20;
-// 30% of the transaction fee is burned
+// 30% of the transaction fee is burned.
 // This is to reduce the supply over time
 // and also to prevent spamming the network with low fee transactions
-// or free tx from miners
-// This should be enabled once Smart Contracts are released
+// or free tx from miners.
+// This should be enabled once Smart Contracts are released.
 pub const TRANSACTION_FEE_BURN_PERCENT: u64 = 30;
 
 // Developer address for paying dev fees until Smart Contracts integration
@@ -99,33 +100,33 @@ pub const TRANSACTION_FEE_BURN_PERCENT: u64 = 30;
 pub const DEV_ADDRESS: &str = "xel:vs3mfyywt0fjys0rgslue7mm4wr23xdgejsjk0ld7f2kxng4d4nqqnkdufz";
 
 // Chain sync config
-// minimum X seconds between each chain sync request per peer
+// Minimum X seconds between each chain sync request per peer
 pub const CHAIN_SYNC_DELAY: u64 = 5;
-// wait maximum between each chain sync request to peers
+// Wait maximum between each chain sync request to peers
 pub const CHAIN_SYNC_TIMEOUT_SECS: u64 = CHAIN_SYNC_DELAY * 3;
-// first 30 blocks are sent in linear way, then it's exponential
+// First 30 blocks are sent in linear way, then it's exponential
 pub const CHAIN_SYNC_REQUEST_EXPONENTIAL_INDEX_START: usize = 30;
-// allows up to X blocks id (hash + height) sent for request
+// Allows up to X blocks id (hash + height) sent for request
 pub const CHAIN_SYNC_REQUEST_MAX_BLOCKS: usize = 64;
-// minimum X blocks hashes sent for response
+// Minimum X blocks hashes sent for response
 pub const CHAIN_SYNC_RESPONSE_MIN_BLOCKS: usize = 512;
 // Default response blocks sent/accepted
 pub const CHAIN_SYNC_DEFAULT_RESPONSE_BLOCKS: usize = 4096;
-// allows up to X blocks hashes sent for response
+// Allows up to X blocks hashes sent for response
 pub const CHAIN_SYNC_RESPONSE_MAX_BLOCKS: usize = 16384;
-// send last 10 heights
+// Send last 10 heights
 pub const CHAIN_SYNC_TOP_BLOCKS: usize = 10;
 
 // P2p rules
-// time between each ping
+// Time between each ping
 pub const P2P_PING_DELAY: u64 = 10;
-// time in seconds between each update of peerlist
+// Time in seconds between each update of peerlist
 pub const P2P_PING_PEER_LIST_DELAY: u64 = 60 * 5;
-// maximum number of addresses to be send
+// Maximum number of addresses to be send
 pub const P2P_PING_PEER_LIST_LIMIT: usize = 16;
-// default number of maximum peers
+// Default number of maximum peers
 pub const P2P_DEFAULT_MAX_PEERS: usize = 32;
-// time in seconds between each time we try to connect to a new peer
+// Time in seconds between each time we try to connect to a new peer
 pub const P2P_EXTEND_PEERLIST_DELAY: u64 = 60;
 // Peer wait on error accept new p2p connections in seconds
 pub const P2P_PEER_WAIT_ON_ERROR: u64 = 15;
@@ -136,37 +137,37 @@ pub const P2P_DEFAULT_CONCURRENCY_TASK_COUNT_LIMIT: usize = 4;
 // Heartbeat interval in seconds to check if peer is still alive
 pub const P2P_HEARTBEAT_INTERVAL: u64 = P2P_PING_DELAY / 2;
 // Timeout in seconds
-// If we didn't receive any packet from a peer during this time, we disconnect it
+// If we didn't receive any packets from a peer during this time, we disconnect it
 pub const P2P_PING_TIMEOUT: u64 = P2P_PING_DELAY * 6;
 
 // Peer rules
-// number of seconds to reset the counter
-// Set to 30 minutes
+// Number of seconds to reset the counter.
+// Set to 30 minutes.
 pub const PEER_FAIL_TIME_RESET: u64 = 30 * 60;
-// number of fail to disconnect the peer
+// Number of fail to disconnect the peer
 pub const PEER_FAIL_LIMIT: u8 = 50;
-// number of fail during handshake before temp ban
+// Number of fail during handshake before temp ban
 pub const PEER_FAIL_TO_CONNECT_LIMIT: u8 = 3;
-// number of seconds to temp ban the peer in case of fail reached
-// Set to 15 minutes
+// Number of seconds to temp ban the peer in case of fail reached.
+// Set to 15 minutes.
 pub const PEER_TEMP_BAN_TIME: u64 = 15 * 60;
-// number of seconds to temp ban the peer in case of fail reached during handshake
-// Set to 1 minute
+// Number of seconds to temp ban the peer in case of fail reached during handshake.
+// Set to 1 minute.
 pub const PEER_TEMP_BAN_TIME_ON_CONNECT: u64 = 60;
-// millis until we timeout
+// Millis until we timeout
 pub const PEER_TIMEOUT_REQUEST_OBJECT: u64 = 15_000;
-// millis until we timeout during a bootstrap request
+// Millis until we timeout during a bootstrap request
 pub const PEER_TIMEOUT_BOOTSTRAP_STEP: u64 = 60_000;
-// millis until we timeout during a handshake
+// Millis until we timeout during a handshake
 pub const PEER_TIMEOUT_INIT_CONNECTION: u64 = 5_000;
-// millis until we timeout during outgoing connection try
+// Millis until we timeout during outgoing connection try
 pub const PEER_TIMEOUT_INIT_OUTGOING_CONNECTION: u64 = 30_000;
-// millis until we timeout during a handshake
+// Millis until we timeout during a handshake
 pub const PEER_TIMEOUT_DISCONNECT: u64 = 1_500;
 // 16 additional bytes are for AEAD from ChaCha20Poly1305
 pub const PEER_MAX_PACKET_SIZE: u32 = MAX_BLOCK_SIZE as u32 + 16;
-// Peer TX cache size
-// This is how many elements are stored in the LRU cache at maximum
+// Peer TX cache size.
+// This is how many elements are stored in the LRU cache at maximum.
 pub const PEER_TX_CACHE_SIZE: usize = 10240;
 // Peer Block cache size
 pub const PEER_BLOCK_CACHE_SIZE: usize = 1024;
@@ -243,7 +244,7 @@ const MAINNET_GENESIS_BLOCK_HASH: Hash = Hash::new([175, 118, 37, 203, 175, 200,
 const TESTNET_GENESIS_BLOCK_HASH: Hash = Hash::new([171, 50, 219, 186, 28, 164, 189, 225, 197, 167, 187, 143, 213, 59, 217, 238, 51, 242, 133, 181, 188, 235, 151, 50, 110, 33, 185, 188, 100, 146, 23, 132]);
 
 // Genesis block getter
-// This is necessary to prevent having the same Genesis Block for differents network
+// This is necessary to prevent having the same Genesis Block for different network
 // Dev returns none to generate a new genesis block each time it starts a chain
 pub fn get_hex_genesis_block(network: &Network) -> Option<&str> {
     match network {
@@ -276,9 +277,9 @@ pub const fn get_seed_nodes(network: &Network) -> &[&str] {
     }
 }
 
-// Get minimum difficulty based on the network
-// Mainnet has a minimum difficulty to prevent spamming the network
-// Testnet has a lower difficulty to allow faster block generation
+// Get minimum difficulty based on the network.
+// Mainnet has a higher minimum difficulty to prevent spamming the network.
+// Testnet has a lower difficulty to allow faster block generation.
 pub const fn get_minimum_difficulty(network: &Network) -> Difficulty {
     match network {
         Network::Mainnet => MAINNET_MINIMUM_DIFFICULTY,

--- a/xelis_daemon/src/core/blockdag.rs
+++ b/xelis_daemon/src/core/blockdag.rs
@@ -13,7 +13,7 @@ use super::{
     error::BlockchainError,
 };
 
-// sort the scores by cumulative difficulty and, if equals, by hash value
+// Sort the scores by cumulative difficulty and, if equal, by hash value
 pub fn sort_descending_by_cumulative_difficulty<T>(scores: &mut Vec<(T, CumulativeDifficulty)>)
 where
     T: AsRef<Hash>,
@@ -32,7 +32,7 @@ where
     }
 }
 
-// sort the scores by cumulative difficulty and, if equals, by hash value
+// Sort the scores by cumulative difficulty and, if equal, by hash value
 pub fn sort_ascending_by_cumulative_difficulty<T>(scores: &mut Vec<(T, CumulativeDifficulty)>)
 where
     T: AsRef<Hash>,
@@ -51,9 +51,9 @@ where
     }
 }
 
-// Sort the TIPS by cumulative difficulty
-// If the cumulative difficulty is the same, the hash value is used to sort
-// Hashes are sorted in descending order
+// Sort the TIPS by cumulative difficulty.
+// If the cumulative difficulty is the same, the hash value is used to sort.
+// Hashes are sorted in descending order.
 pub async fn sort_tips<S, I>(storage: &S, tips: I) -> Result<IndexSet<Hash>, BlockchainError>
 where
     S: Storage,
@@ -77,7 +77,7 @@ where
     }
 }
 
-// determine he lowest height possible based on tips and do N+1
+// Determine the lowest height possible based on tips and do N+1
 pub async fn calculate_height_at_tips<'a, D, I>(provider: &D, tips: I) -> Result<u64, BlockchainError>
 where
     D: DifficultyProvider,
@@ -99,7 +99,7 @@ where
     Ok(height)
 }
 
-// find the best tip based on cumulative difficulty of the blocks
+// Find the best tip based on cumulative difficulty of the blocks
 pub async fn find_best_tip_by_cumulative_difficulty<'a, D, I>(provider: &D, tips: I) -> Result<&'a Hash, BlockchainError>
 where
     D: DifficultyProvider,

--- a/xelis_daemon/src/core/difficulty/v1.rs
+++ b/xelis_daemon/src/core/difficulty/v1.rs
@@ -15,12 +15,12 @@ const LEFT_SHIFT: VarUint = VarUint::from_u64(1 << SHIFT);
 // Process noise covariance: 5% of shift
 const PROCESS_NOISE_COVAR: VarUint = VarUint::from_u64((1 << SHIFT) / 100 * 5);
 
-// Initial estimate covariance
-// It is used by first blocks
+// Initial estimate covariance.
+// It is used by first blocks.
 pub const P: VarUint = LEFT_SHIFT;
 
-// Calculate the required difficulty for the next block based on the solve time of the previous block
-// We are using a Kalman filter to estimate the hashrate and adjust the difficulty
+// Calculate the required difficulty for the next block based on the solve time of the previous block.
+// We are using a Kalman filter to estimate the hashrate and adjust the difficulty.
 pub fn calculate_difficulty(solve_time: TimestampMillis, previous_difficulty: Difficulty, p: VarUint, minimum_difficulty: Difficulty) -> (Difficulty, VarUint) {
     let z = previous_difficulty / solve_time;
     trace!("Calculating difficulty v1, solve time: {}, previous_difficulty: {}, z: {}, p: {}", format_duration(Duration::from_millis(solve_time)), format_difficulty(previous_difficulty), z, p);

--- a/xelis_daemon/src/core/difficulty/v2.rs
+++ b/xelis_daemon/src/core/difficulty/v2.rs
@@ -22,8 +22,8 @@ const PROCESS_NOISE_COVAR: VarUint = VarUint::from_u64((1 << SHIFT) * SHIFT / MI
 // It is used by first blocks
 pub const P: VarUint = LEFT_SHIFT;
 
-// Calculate the required difficulty for the next block based on the solve time of the previous block
-// We are using a Kalman filter to estimate the hashrate and adjust the difficulty
+// Calculate the required difficulty for the next block based on the solve time of the previous block.
+// We are using a Kalman filter to estimate the hashrate and adjust the difficulty.
 pub fn calculate_difficulty(solve_time: TimestampMillis, previous_difficulty: Difficulty, p: VarUint, minimum_difficulty: Difficulty) -> (Difficulty, VarUint) {
     let z = previous_difficulty * MILLIS_PER_SECOND / solve_time;
     trace!("Calculating difficulty v2, solve time: {}, previous_difficulty: {}, z: {}, p: {}", format_duration(Duration::from_millis(solve_time)), format_difficulty(previous_difficulty), z, p);

--- a/xelis_daemon/src/core/error.rs
+++ b/xelis_daemon/src/core/error.rs
@@ -112,7 +112,7 @@ pub enum BlockchainError {
     #[error("Timestamp {} is less than parent", _0)]
     TimestampIsLessThanParent(TimestampMillis),
     #[error("Timestamp {} is greater than current time {}", _0, _1)]
-    TimestampIsInFuture(TimestampMillis, TimestampMillis), // left is expected, right is got
+    TimestampIsInFuture(TimestampMillis, TimestampMillis), // Left is expected, right is got
     #[error("Block height mismatch, expected {}, got {}.", _0, _1)]
     InvalidBlockHeight(u64, u64),
     #[error("Block height is zero which is not allowed")]
@@ -152,10 +152,10 @@ pub enum BlockchainError {
     #[error("Tx {} is already in block", _0)]
     TxAlreadyInBlock(Hash),
     #[error("Duplicate registration tx for address '{}' found in same block", _0)]
-    DuplicateRegistration(Address), // address
+    DuplicateRegistration(Address), // Address
     #[error("Invalid Tx fee, expected at least {}, got {}", format_xelis(*_0), format_xelis(*_1))]
     InvalidTxFee(u64, u64),
-    #[error("Fees are lower for this TX than the overrided TX, expected at least {}, got {}", format_xelis(*_0), format_xelis(*_1))]
+    #[error("Fees are lower for this TX than the overridden TX, expected at least {}, got {}", format_xelis(*_0), format_xelis(*_1))]
     FeesToLowToOverride(u64, u64),
     #[error("No account found for {}", _0)]
     AccountNotFound(Address),
@@ -237,7 +237,7 @@ pub enum BlockchainError {
     UnsupportedOperation,
     #[error("Data not found on disk: {}", _0)]
     NotFoundOnDisk(DiskContext),
-    #[error("Invalid paramater: max chain response size isn't in range")]
+    #[error("Invalid parameter: max chain response size isn't in range")]
     ConfigMaxChainResponseSize,
     #[error("Invalid config sync mode")]
     ConfigSyncMode,

--- a/xelis_daemon/src/core/hard_fork.rs
+++ b/xelis_daemon/src/core/hard_fork.rs
@@ -21,7 +21,7 @@ pub fn get_hard_fork_at_height(network: &Network, height: u64) -> Option<&HardFo
 }
 
 // Get the version of the hard fork at a given height
-// and returns true if there is a hard fork (version change) at that height
+// and returns true if there is a hard fork (version change) at that height.
 pub fn has_hard_fork_at_height(network: &Network, height: u64) -> (bool, BlockVersion) {
     match get_hard_fork_at_height(network, height) {
         Some(hard_fork) => (hard_fork.height == height, hard_fork.version),
@@ -42,9 +42,9 @@ pub fn get_pow_algorithm_for_version(version: BlockVersion) -> Algorithm {
     }
 }
 
-// This function checks if a version is matching the requirements
-// it split the version if it contains a `-` and only takes the first part
-// to support our git commit hash
+// This function checks if a version is matching the requirements.
+// If the version contains a `-`, split it and use only the first part,
+// which supports our git commit hash.
 fn is_version_matching_requirement(version: &str, req: &str) -> Result<bool> {
     let r = semver::VersionReq::parse(req)?;
     let str_version = match version.split_once('-') {

--- a/xelis_daemon/src/core/merkle.rs
+++ b/xelis_daemon/src/core/merkle.rs
@@ -2,11 +2,10 @@ use std::borrow::Cow;
 
 use xelis_common::{crypto::{hash, Hash, HASH_SIZE}, serializer::Serializer};
 
-// This builder is used to build a merkle tree from a list of hashes
-// It uses a bottom-up approach to build the tree
-// The tree is built by taking pairs of hashes and hashing them together
-// The resulting hash is then added to the list of hashes
-// This process is repeated until there is only one hash left
+// This builder constructs a Merkle tree from a list of hashes.
+// It uses a bottom-up approach, pairing and hashing hashes together.
+// The resulting hash from each pair is added to the list of hashes.
+// This process continues until only one hash remains.
 pub struct MerkleBuilder<'a> {
     hashes: Vec<Cow<'a, Hash>>
 }

--- a/xelis_daemon/src/core/nonce_checker.rs
+++ b/xelis_daemon/src/core/nonce_checker.rs
@@ -38,8 +38,8 @@ impl AccountEntry {
     }
 }
 
-// A simple cache that checks if a nonce has already been used
-// Stores the topoheight of the block that used the nonce
+// A simple cache that checks if a nonce has already been used.
+// Stores the topoheight of the block that used the nonce.
 pub struct NonceChecker {
     cache: HashMap<PublicKey, AccountEntry>,
 }
@@ -51,7 +51,7 @@ impl NonceChecker {
         }
     }
 
-    // Undo the nonce usage
+    // Undo the nonce usage.
     // We remove it from the used nonces list and revert the expected nonce to the previous nonce if present.
     pub fn undo_nonce(&mut self, key: &PublicKey, nonce: u64) {
         if let Some(entry) = self.cache.get_mut(key) {
@@ -65,8 +65,8 @@ impl NonceChecker {
         }
     }
 
-    // Key may be cloned on first entry
-    // Returns false if nonce is already used
+    // Key may be cloned on first entry.
+    // Returns false if nonce is already used.
     pub async fn use_nonce<S: Storage>(&mut self, storage: &S, key: &PublicKey, nonce: u64, topoheight: u64) -> Result<bool, BlockchainError> {
         trace!("use_nonce {} for {} at topoheight {}", nonce, key.as_address(storage.is_mainnet()), topoheight);
 

--- a/xelis_daemon/src/core/simulator.rs
+++ b/xelis_daemon/src/core/simulator.rs
@@ -50,8 +50,8 @@ impl Display for Simulator {
 }
 
 impl Simulator {
-    // Start the Simulator mode to generate new blocks automatically
-    // It generates random miner keys and mine blocks with them
+    // Start the Simulator mode to generate new blocks automatically.
+    // It generates random miner keys and mine blocks with them.
     pub async fn start<S: Storage>(&self, blockchain: Arc<Blockchain<S>>) {
         let millis_interval = match self {
             Self::Stress => 300,
@@ -90,7 +90,7 @@ impl Simulator {
                 }
             }
 
-            // TODO
+            // TODO:
             // let max_txs = match self {
             //     Self::Stress => 200,
             //     _ => 15
@@ -118,7 +118,7 @@ impl Simulator {
         blocks
     }
 
-    // TODO use transaction builder
+    // TODO: Use transaction builder
     // async fn generate_txs_in_mempool(&self, max_txs: usize, max_transfers: usize, max_amount: u64, rng: &mut OsRng, keys: &Vec<KeyPair>, blockchain: &Arc<Blockchain<impl Storage>>) {
     //     info!("Adding simulated TXs in mempool");
     //     let n = rng.gen_range(0..max_txs);

--- a/xelis_daemon/src/core/state/mempool_state.rs
+++ b/xelis_daemon/src/core/state/mempool_state.rs
@@ -22,10 +22,10 @@ use crate::core::{
 struct Account<'a> {
     // Account nonce used to verify valid transaction
     nonce: u64,
-    // Assets ready as source for any transfer/transaction
+    // Assets ready as source for any transfer/transaction.
     // TODO: they must store also the ciphertext change
-    // It will be added by next change at each TX
-    // This is necessary to easily build the final user balance
+    // It will be added by next change at each TX.
+    // This is necessary to easily build the final user balance.
     assets: HashMap<&'a Hash, Ciphertext>
 }
 
@@ -36,8 +36,8 @@ pub struct MempoolState<'a, S: Storage> {
     storage: &'a S,
     // Receiver balances
     receiver_balances: HashMap<&'a PublicKey, HashMap<&'a Hash, Ciphertext>>,
-    // Sender accounts
-    // This is used to verify ZK Proofs and store/update nonces
+    // Sender accounts.
+    // This is used to verify ZK Proofs and store/update nonces.
     accounts: HashMap<&'a PublicKey, Account<'a>>,
     // The current stable topoheight of the chain
     stable_topoheight: u64,
@@ -66,9 +66,9 @@ impl<'a, S: Storage> MempoolState<'a, S> {
         Some(account.assets)
     }
 
-    // Retrieve the receiver balance
-    // We never store the receiver balance in mempool, only outgoing balances
-    // So we just get it from our internal cache or from storage
+    // Retrieve the receiver balance.
+    // We never store the receiver balance in mempool, only outgoing balances.
+    // So we just get it from our internal cache or from storage.
     async fn internal_get_receiver_balance<'b>(&'b mut self, account: &'a PublicKey, asset: &'a Hash) -> Result<&'b mut Ciphertext, BlockchainError> {
         match self.receiver_balances.entry(account).or_insert_with(HashMap::new).entry(asset) {
             Entry::Occupied(entry) => Ok(entry.into_mut()),
@@ -86,11 +86,11 @@ impl<'a, S: Storage> MempoolState<'a, S> {
         Ok(version.take_balance_with(output).take_ciphertext()?)
     }
 
-    // Retrieve the sender balance
+    // Retrieve the sender balance.
     // For this, we first look in our internal cache,
-    // If not found, we check in mempool cache,
-    // If still not present, we check in storage and determine using reference
-    // Which version to use
+    // if not found, we check in mempool cache,
+    // if still not present, we check in storage and determine using reference
+    // which version to use.
     async fn internal_get_sender_balance<'b>(&'b mut self, key: &'a PublicKey, asset: &'a Hash, reference: &Reference) -> Result<&'b mut Ciphertext, BlockchainError> {
         match self.accounts.entry(key) {
             Entry::Occupied(o) => {
@@ -133,8 +133,8 @@ impl<'a, S: Storage> MempoolState<'a, S> {
         }
     }
 
-    // Retrieve the account nonce
-    // Only sender accounts should be used here
+    // Retrieve the account nonce.
+    // Only sender accounts should be used here.
     async fn internal_get_account_nonce(&mut self, key: &'a PublicKey) -> Result<u64, BlockchainError> {
         match self.accounts.entry(key) {
             Entry::Occupied(o) => Ok(o.get().nonce),
@@ -155,9 +155,9 @@ impl<'a, S: Storage> MempoolState<'a, S> {
         }
     }
 
-    // Update the account nonce
-    // Only sender accounts should be used here
-    // For each TX, we must update the nonce by one
+    // Update the account nonce.
+    // Only sender accounts should be used here.
+    // For each TX, we must update the nonce by one.
     async fn internal_update_account_nonce(&mut self, account: &'a PublicKey, new_nonce: u64) -> Result<(), BlockchainError> {
         match self.accounts.entry(account) {
             Entry::Occupied(mut o) => {
@@ -207,8 +207,8 @@ impl<'a, S: Storage> BlockchainVerificationState<'a, BlockchainError> for Mempoo
         self.internal_get_sender_balance(account, asset, reference).await
     }
 
-    /// Apply new output to a sender account
-    /// In this state, we don't need to store the output
+    /// Apply new output to a sender account.
+    /// In this state, we don't need to store the output.
     async fn add_sender_output(
         &mut self,
         _: &'a PublicKey,

--- a/xelis_daemon/src/core/storage/mod.rs
+++ b/xelis_daemon/src/core/storage/mod.rs
@@ -24,42 +24,42 @@ pub trait Storage: BlockExecutionOrderProvider + DagOrderProvider + PrunedTopohe
     // Clear caches if exists
     async fn clear_caches(&mut self) -> Result<(), BlockchainError>;
 
-    // delete block at topoheight, and all pointers (hash_at_topo, topo_by_hash, reward, supply, diff, cumulative diff...)
+    // Delete block at topoheight, and all pointers (hash_at_topo, topo_by_hash, reward, supply, diff, cumulative diff...)
     async fn delete_block_at_topoheight(&mut self, topoheight: u64) -> Result<(Hash, Arc<BlockHeader>, Vec<(Hash, Arc<Transaction>)>), BlockchainError>;
 
-    // delete versioned balances at topoheight
+    // Delete versioned balances at topoheight
     async fn delete_versioned_balances_at_topoheight(&mut self, topoheight: u64) -> Result<(), BlockchainError>;
 
-    // delete versioned nonces at topoheight
+    // Delete versioned nonces at topoheight
     async fn delete_versioned_nonces_at_topoheight(&mut self, topoheight: u64) -> Result<(), BlockchainError>;
 
-    // delete versioned balances above topoheight
+    // Delete versioned balances above topoheight
     async fn delete_versioned_balances_above_topoheight(&mut self, topoheight: u64) -> Result<(), BlockchainError>;
 
-    // delete versioned nonces above topoheight
+    // Delete versioned nonces above topoheight
     async fn delete_versioned_nonces_above_topoheight(&mut self, topoheight: u64) -> Result<(), BlockchainError>;
 
-    // delete account registrations above topoheight
+    // Delete account registrations above topoheight
     async fn delete_registrations_above_topoheight(&mut self, topoheight: u64) -> Result<(), BlockchainError>;
 
-    // delete account registrations below topoheight
+    // Delete account registrations below topoheight
     async fn delete_registrations_below_topoheight(&mut self, topoheight: u64) -> Result<(), BlockchainError>;
 
-    // delete versioned balances below topoheight
+    // Delete versioned balances below topoheight
     async fn delete_versioned_balances_below_topoheight(&mut self, topoheight: u64) -> Result<(), BlockchainError>;
 
-    // delete versioned nonces below topoheight
+    // Delete versioned nonces below topoheight
     async fn delete_versioned_nonces_below_topoheight(&mut self, topoheight: u64) -> Result<(), BlockchainError>;
 
-    // delete all versions of balances under the specified topoheight
-    // for those who don't have more recents, set it to the topoheight
-    // for those above it, cut the chain by deleting the previous topoheight when it's going under
+    // Delete all balance versions below the specified topoheight.
+    // For entries with no more recent versions, set their height to the specified topoheight.
+    // For entries with newer versions, truncate the chain by removing older versions that fall below the topoheight.
     async fn create_snapshot_balances_at_topoheight(&mut self, topoheight: u64) -> Result<(), BlockchainError>;
 
-    // same as above but for nonces
+    // Same as above but for nonces
     async fn create_snapshot_nonces_at_topoheight(&mut self, topoheight: u64) -> Result<(), BlockchainError>;
 
-    // same as above but for registrations
+    // Same as above but for registrations
     async fn create_snapshot_registrations_at_topoheight(&mut self, topoheight: u64) -> Result<(), BlockchainError>;
 
     // Count is the number of blocks (topoheight) to rewind

--- a/xelis_daemon/src/core/storage/providers/account.rs
+++ b/xelis_daemon/src/core/storage/providers/account.rs
@@ -6,24 +6,24 @@ use crate::core::{error::{BlockchainError, DiskContext}, storage::SledStorage};
 
 #[async_trait]
 pub trait AccountProvider {
-    // first time we saw this account on chain
+    // First time we saw this account on chain
     async fn get_account_registration_topoheight(&self, key: &PublicKey) -> Result<u64, BlockchainError>;
 
-    // set the registration topoheight
+    // Set the registration topoheight
     async fn set_account_registration_topoheight(&mut self, key: &PublicKey, topoheight: u64) -> Result<(), BlockchainError>;
 
     // Check if account is registered
     async fn is_account_registered(&self, key: &PublicKey) -> Result<bool, BlockchainError>;
 
-    // Check if account is registered at topoheight
-    // This will check that the registration topoheight is less or equal to the given topoheight
+    // Check if account is registered at topoheight.
+    // This will check that the registration topoheight is less or equal to the given topoheight.
     async fn is_account_registered_at_topoheight(&self, key: &PublicKey, topoheight: u64) -> Result<bool, BlockchainError>;
 
     // Delete all registrations at a certain topoheight
     async fn delete_registrations_at_topoheight(&mut self, topoheight: u64) -> Result<(), BlockchainError>;
 
-    // Get registered accounts supporting pagination and filtering by topoheight
-    // Returned keys must have a nonce or a balance updated in the range given
+    // Get registered accounts supporting pagination and filtering by topoheight.
+    // Returned keys must have a nonce or a balance updated in the range given.
     async fn get_registered_keys(&self, maximum: usize, skip: usize, minimum_topoheight: u64, maximum_topoheight: u64) -> Result<IndexSet<PublicKey>, BlockchainError>;
 }
 

--- a/xelis_daemon/src/core/storage/providers/asset.rs
+++ b/xelis_daemon/src/core/storage/providers/asset.rs
@@ -21,11 +21,11 @@ pub trait AssetProvider {
     async fn get_asset(&self, hash: &Hash) -> Result<AssetData, BlockchainError>;
 
     // Get all available assets
-    // TODO: replace with impl Iterator<Item = Result<Hash, BlockchainError>> when async trait methods are stable
+    // TODO: Replace with impl Iterator<Item = Result<Hash, BlockchainError>> when async trait methods are stable
     async fn get_assets(&self) -> Result<Vec<Hash>, BlockchainError>;
 
     // Get a partial list of assets supporting pagination and filtering by topoheight
-    // TODO: replace with impl Iterator<Item = Result<Hash, BlockchainError>> when async trait methods are stable
+    // TODO: Replace with impl Iterator<Item = Result<Hash, BlockchainError>> when async trait methods are stable
     async fn get_partial_assets(&self, maximum: usize, skip: usize, minimum_topoheight: u64, maximum_topoheight: u64) -> Result<IndexSet<AssetWithData>, BlockchainError>;
 
     // Get chunked assets
@@ -55,7 +55,7 @@ impl AssetProvider for SledStorage {
         self.load_from_disk(&self.assets, asset.as_bytes(), DiskContext::Asset)
     }
 
-    // we are forced to read from disk directly because cache may don't have all assets in memory
+    // We are forced to read from disk directly because cache may not have all assets in memory
     async fn get_assets(&self) -> Result<Vec<Hash>, BlockchainError> {
         trace!("get assets");
 
@@ -71,7 +71,7 @@ impl AssetProvider for SledStorage {
         for el in self.assets.iter() {
             let (key, value) = el?;
             let data = AssetData::from_bytes(&value)?;
-            // check that we have a registered asset before the maximum topoheight
+            // Check that we have a registered asset before the maximum topoheight
             if data.get_topoheight() >= minimum_topoheight && data.get_topoheight() <= maximum_topoheight {
                 if skip_count < skip {
                     skip_count += 1;
@@ -108,7 +108,7 @@ impl AssetProvider for SledStorage {
         }).collect()
     }
 
-    // count assets in storage
+    // Dount assets in storage
     async fn count_assets(&self) -> Result<u64, BlockchainError> {
         trace!("count assets");
         Ok(self.assets_count.load(Ordering::SeqCst))

--- a/xelis_daemon/src/core/storage/providers/block.rs
+++ b/xelis_daemon/src/core/storage/providers/block.rs
@@ -66,7 +66,7 @@ impl BlockProvider for SledStorage {
 
         // Store transactions
         let mut txs_count = 0;
-        for (hash, tx) in block.get_transactions().iter().zip(txs) { // first save all txs, then save block
+        for (hash, tx) in block.get_transactions().iter().zip(txs) { // First save all txs, then save block
             if !self.has_transaction(hash).await? {
                 self.transactions.insert(hash.as_bytes(), tx.to_bytes())?;
                 txs_count += 1;

--- a/xelis_daemon/src/core/storage/providers/block_execution_order.rs
+++ b/xelis_daemon/src/core/storage/providers/block_execution_order.rs
@@ -9,7 +9,7 @@ use crate::core::{
 };
 
 // This provider tracks the order in which blocks are added in the chain.
-// This is independant of the DAG order and is used for debug purposes.
+// This is independent of the DAG order and is used for debug purposes.
 #[async_trait]
 pub trait BlockExecutionOrderProvider {
     // Get the blocks execution order

--- a/xelis_daemon/src/core/storage/providers/blocks_at_height.rs
+++ b/xelis_daemon/src/core/storage/providers/blocks_at_height.rs
@@ -10,8 +10,8 @@ use crate::core::{
     storage::SledStorage,
 };
 
-// This struct is used to store the blocks hashes at a specific height
-// We use an IndexSet to store the hashes and maintains the order we processed them
+// This struct is used to store the blocks hashes at a specific height.
+// We use an IndexSet to store the hashes and maintains the order we processed them.
 struct OrderedHashes(IndexSet<Hash>);
 
 #[async_trait]

--- a/xelis_daemon/src/core/storage/providers/dag_order.rs
+++ b/xelis_daemon/src/core/storage/providers/dag_order.rs
@@ -25,7 +25,7 @@ impl DagOrderProvider for SledStorage {
         self.topo_by_hash.insert(hash.as_bytes(), topoheight.to_bytes())?;
         self.hash_at_topo.insert(topoheight.to_be_bytes(), hash.as_bytes())?;
 
-        // save in cache
+        // Save in cache
         if let Some(cache) = &self.topo_by_hash_cache {
             let mut topo = cache.lock().await;
             topo.put(hash.clone(), topoheight);

--- a/xelis_daemon/src/core/storage/providers/difficulty.rs
+++ b/xelis_daemon/src/core/storage/providers/difficulty.rs
@@ -19,7 +19,7 @@ use crate::core::{
     storage::SledStorage,
 };
 
-// this trait is useful for P2p to check itself the validty of a chain
+// This trait is useful for P2p to check itself the validity of a chain
 #[async_trait]
 pub trait DifficultyProvider {
     // Get the block height using its hash
@@ -52,7 +52,7 @@ pub trait DifficultyProvider {
 
 #[async_trait]
 impl DifficultyProvider for SledStorage {
-    // TODO optimize all these functions to read only what is necessary
+    // TODO: Optimize all these functions to read only what is necessary
     async fn get_height_for_block_hash(&self, hash: &Hash) -> Result<u64, BlockchainError> {
         trace!("get height for block hash {}", hash);
         let block = self.get_block_header_by_hash(hash).await?;

--- a/xelis_daemon/src/core/storage/providers/merkle.rs
+++ b/xelis_daemon/src/core/storage/providers/merkle.rs
@@ -3,11 +3,11 @@ use log::trace;
 use xelis_common::{crypto::Hash, serializer::Serializer};
 use crate::core::{error::{BlockchainError, DiskContext}, storage::SledStorage};
 
-// Merkle Hash provider allow to give a Hash at a specific topoheight
-// The merkle hash only contains account balances
-// Because TXs and block rewards are applied on account balances
-// Balances are the only thing that needs to be proven
-// NOTE: We are based on the topoheight because of DAG reorgs as it's the main consensus
+// Merkle Hash provider gives a hash at a specific topoheight.
+// The Merkle hash includes only account balances.
+// Transactions and block rewards affect account balances.
+// Thus, balances are the primary data that needs to be proven.
+// NOTE: We use topoheight due to DAG reorgs, as it is the main consensus metric.
 #[async_trait]
 pub trait MerkleHashProvider {
     // Get the merkle hash at a specific topoheight

--- a/xelis_daemon/src/core/storage/providers/pruned_topoheight.rs
+++ b/xelis_daemon/src/core/storage/providers/pruned_topoheight.rs
@@ -7,10 +7,10 @@ use crate::core::{
 // This trait is used for pruning
 #[async_trait]
 pub trait PrunedTopoheightProvider {
-    // get the pruned topoheight
+    // Get the pruned topoheight
     async fn get_pruned_topoheight(&self) -> Result<Option<u64>, BlockchainError>;
 
-    // set the pruned topoheight on disk
+    // Set the pruned topoheight on disk
     async fn set_pruned_topoheight(&mut self, pruned_topoheight: u64) -> Result<(), BlockchainError>;
 }
 

--- a/xelis_daemon/src/core/tx_selector.rs
+++ b/xelis_daemon/src/core/tx_selector.rs
@@ -16,7 +16,7 @@ use xelis_common::{
     }
 };
 
-// this struct is used to store transaction with its hash and its size in bytes
+// This struct is used to store transaction with its hash and its size in bytes
 pub struct TxSelectorEntry<'a> {
     // Hash of the transaction
     pub hash: &'a Arc<Hash>,
@@ -34,9 +34,9 @@ impl PartialEq for TxSelectorEntry<'_> {
 
 impl Eq for TxSelectorEntry<'_> {}
 
-// this struct is used to store transactions in a queue
-// and to order them by fees
-// Each Transactions is for a specific sender
+// This struct is used to store transactions in a queue
+// and to order them by fees.
+// Each Transactions is for a specific sender.
 #[derive(PartialEq, Eq)]
 struct Transactions<'a>(VecDeque<TxSelectorEntry<'a>>);
 
@@ -52,9 +52,9 @@ impl Ord for Transactions<'_> {
     }
 }
 
-// TX selector is used to select transactions from the mempool
-// It create sub groups of transactions by sender and order them by nonces
-// It joins all sub groups in a queue that is ordered by fees
+// TX selector is used to select transactions from the mempool.
+// It create sub groups of transactions by sender and order them by nonces.
+// It joins all sub groups in a queue that is ordered by fees.
 pub struct TxSelector<'a> {
     queue: BinaryHeap<Transactions<'a>>
 }
@@ -67,7 +67,7 @@ impl<'a> TxSelector<'a> {
     {
         let mut queue = BinaryHeap::new();
 
-        // push every group to the queue
+        // Push every group to the queue
         for group in groups {
             queue.push(Transactions(VecDeque::from(group)));
         }
@@ -112,12 +112,12 @@ impl<'a> TxSelector<'a> {
 
     // Get the next transaction with the highest fee
     pub fn next(&mut self) -> Option<TxSelectorEntry<'a>> {
-        // get the group with the highest fee
+        // Get the group with the highest fee
         let mut group = self.queue.pop()?;
-        // get the entry with the highest fee from this group
+        // Get the entry with the highest fee from this group
         let entry = group.0.pop_front()?;
 
-        // if its not empty, push it back to the queue
+        // If its not empty, push it back to the queue
         if !group.0.is_empty() {
             self.queue.push(group);
         }

--- a/xelis_daemon/src/main.rs
+++ b/xelis_daemon/src/main.rs
@@ -100,15 +100,15 @@ pub struct NodeConfig {
     /// Disable the log file
     #[clap(long)]
     disable_file_logging: bool,
-    /// Disable the log filename date based
+    /// Disable the log filename date based.
     /// If disabled, the log file will be named xelis-daemon.log instead of YYYY-MM-DD.xelis-daemon.log
     #[clap(long)]
     disable_file_log_date_based: bool,
     /// Disable the usage of colors in log
     #[clap(long)]
     disable_log_color: bool,
-    /// Disable terminal interactive mode
-    /// You will not be able to write CLI commands in it or to have an updated prompt
+    /// Disable terminal interactive mode.
+    /// You will not be able to write CLI commands in it or to have an updated prompt.
     #[clap(long)]
     disable_interactive_mode: bool,
     /// Log filename
@@ -208,7 +208,7 @@ async fn run_prompt<S: Storage>(prompt: ShareablePrompt, blockchain: Arc<Blockch
     command_manager.add_command(Command::new("list_unexecuted_transactions", "List all unexecuted transactions", CommandHandler::Async(async_handler!(list_unexecuted_transactions::<S>))))?;
     command_manager.add_command(Command::new("swap_blocks_executions_positions", "Swap the position of two blocks executions", CommandHandler::Async(async_handler!(swap_blocks_executions_positions::<S>))))?;
 
-    // Don't keep the lock for ever
+    // Don't keep the lock forever
     let (p2p, getwork) = {
         let p2p: Option<Arc<P2pServer<S>>> = match blockchain.get_p2p().read().await.as_ref() {
             Some(p2p) => Some(p2p.clone()),
@@ -364,8 +364,8 @@ async fn verify_chain<S: Storage>(manager: &CommandManager, mut args: ArgumentMa
             }
             block_reward
         } else {
-            // We are too near from the pruned topoheight, as we don't know previous blocks we can't verify if block was side block or not for rewards
-            // Let's trust its stored reward
+            // We are too near from the pruned topoheight, as we don't know previous blocks we can't verify if block was side block or not for rewards.
+            // Let's trust its stored reward.
             storage.get_block_reward_at_topo_height(topo).context("Error while retrieving block reward for pruned topo")?
         };
 
@@ -520,7 +520,7 @@ async fn list_assets<S: Storage>(manager: &CommandManager, _: ArgumentManager) -
 
 async fn show_balance<S: Storage>(manager: &CommandManager, mut arguments: ArgumentManager) -> Result<(), CommandError> {
     let prompt = manager.get_prompt();
-    // read address
+    // Read address
     let str_address = prompt.read_input(
         prompt.colorize_str(Color::Green, "Address: "),
         false
@@ -605,7 +605,7 @@ async fn pop_blocks<S: Storage>(manager: &CommandManager, mut arguments: Argumen
 
     info!("Trying to pop {} blocks from chain...", amount);
     let topoheight = blockchain.rewind_chain(amount, false).await.context("Error while rewinding chain")?;
-    info!("Chain as been rewinded until topoheight {}", topoheight);
+    info!("Chain as been rewound until topoheight {}", topoheight);
 
     Ok(())
 }
@@ -621,7 +621,7 @@ async fn clear_mempool<S: Storage>(manager: &CommandManager, _: ArgumentManager)
     Ok(())
 }
 
-// add manually a TX in mempool
+// Add manually a TX in mempool
 async fn add_tx<S: Storage>(manager: &CommandManager, mut arguments: ArgumentManager) -> Result<(), CommandError> {
     let hex = arguments.get_value("hex")?.to_string_value()?;
     let broadcast = if arguments.has_argument("broadcast") {
@@ -898,7 +898,7 @@ async fn mine_block<S: Storage>(manager: &CommandManager, mut arguments: Argumen
     let context = manager.get_context().lock()?;
     let blockchain: &Arc<Blockchain<S>> = context.get()?;
 
-    // Prevent trying to mine a block on mainnet through this as it will keep busy the node for nothing
+    // Prevent attempting to mine a block on mainnet, as it will unnecessarily occupy the node
     if *blockchain.get_network() == Network::Mainnet {
         manager.error("This command is not allowed on mainnet");
         return Ok(())

--- a/xelis_daemon/src/p2p/chain_validator.rs
+++ b/xelis_daemon/src/p2p/chain_validator.rs
@@ -37,18 +37,18 @@ struct BlockData {
     p: VarUint
 }
 
-// Chain validator is used to validate the blocks received from the network
-// We store the blocks in topological order and we verify the proof of work validity
-// This is doing only minimal checks and valid chain order based on topoheight and difficulty
+// Chain validator is used to validate the blocks received from the network.
+// We store the blocks in topological order and we verify the proof of work validity.
+// This involves minimal checks, ensuring valid chain order based on topoheight and difficulty.
 pub struct ChainValidator<'a, S: Storage> {
-    // store all blocks data in topological order
+    // Store all blocks data in topological order
     blocks: IndexMap<Hash, BlockData>,
-    // store all blocks hashes at a specific height
+    // Store all blocks hashes at a specific height
     blocks_at_height: IndexMap<u64, IndexSet<Hash>>,
     // Blockchain reference used to verify current chain state
     blockchain: &'a Blockchain<S>,
-    // This is used to compute the expected topoheight of each new block
-    // It must be 1 topoheight above the common point
+    // This is used to compute the expected topoheight of each new block.
+    // It must be 1 topoheight above the common point.
     starting_topoheight: u64,
 }
 
@@ -63,8 +63,8 @@ impl<'a, S: Storage> ChainValidator<'a, S> {
         }
     }
 
-    // Check if the chain validator has a higher cumulative difficulty than our blockchain
-    // This is used to determine if we should switch to the new chain by popping blocks or not
+    // Check if the chain validator has a higher cumulative difficulty than our blockchain.
+    // This is used to determine if we should switch to the new chain by popping blocks or not.
     pub async fn has_higher_cumulative_difficulty(&self) -> Result<bool, BlockchainError> {
         let new_cumulative_difficulty = self.get_chain_cumulative_difficulty().ok_or(BlockchainError::NotEnoughBlocks)?;
 
@@ -78,15 +78,15 @@ impl<'a, S: Storage> ChainValidator<'a, S> {
         Ok(*new_cumulative_difficulty > current_cumulative_difficulty)
     }
 
-    // Retrieve the cumulative difficulty of the chain validator
-    // It is the cumulative difficulty of the last block added
+    // Retrieve the cumulative difficulty of the chain validator.
+    // It is the cumulative difficulty of the last block added.
     pub fn get_chain_cumulative_difficulty(&self) -> Option<&CumulativeDifficulty> {
         let (_, data) = self.blocks.last()?;
         data.cumulative_difficulty.as_ref()
     }
 
-    // validate the basic chain structure
-    // We expect that the block added is the next block ordered by topoheight
+    // Validate the basic chain structure.
+    // We expect that the block added is the next block ordered by topoheight.
     pub async fn insert_block(&mut self, hash: Hash, header: BlockHeader) -> Result<(), BlockchainError> {
         trace!("Inserting block {} into chain validator", hash);
 
@@ -117,13 +117,13 @@ impl<'a, S: Storage> ChainValidator<'a, S> {
         let tips = header.get_tips();
         let tips_count = tips.len();
 
-        // verify tips count
+        // Verify tips count
         if tips_count == 0 || tips_count > TIPS_LIMIT {
             debug!("Block {} contains {} tips while only {} is accepted", hash, tips_count, TIPS_LIMIT);
             return Err(BlockchainError::InvalidTipsCount(hash, tips_count))
         }
 
-        // verify that we have already all its tips
+        // Verify that we have already all its tips
         {
             for tip in tips {
                 trace!("Checking tip {} for block {}", tip, hash);
@@ -154,8 +154,8 @@ impl<'a, S: Storage> ChainValidator<'a, S> {
         trace!("Common base: {} at height {} and hash {}", base, base_height, hash);
 
 
-        // Store the block in both maps
-        // One is for blocks at height and the other is for the block data
+        // Store the block in both maps.
+        // One is for blocks at height and the other is for the block data.
         self.blocks_at_height.entry(header.get_height()).or_insert_with(IndexSet::new).insert(hash.clone());
         self.blocks.insert(hash.clone(), BlockData { header: Arc::new(header), difficulty, cumulative_difficulty: None, p });
 

--- a/xelis_daemon/src/p2p/error.rs
+++ b/xelis_daemon/src/p2p/error.rs
@@ -164,7 +164,7 @@ pub enum P2pError {
     #[error("Peer sent us a peerlist faster than protocol rules, expected to wait {} seconds more", _0)]
     PeerInvalidPeerListCountdown(u64),
     #[error("Peer sent us a ping packet faster than protocol rules")]
-    PeerInvalidPingCoutdown,
+    PeerInvalidPingCountdown,
     #[error(transparent)]
     BlockchainError(#[from] Box<BlockchainError>),
     #[error("Invalid content in peerlist shared")]

--- a/xelis_daemon/src/p2p/packet/mod.rs
+++ b/xelis_daemon/src/p2p/packet/mod.rs
@@ -84,7 +84,7 @@ pub enum Packet<'a> {
     // packet contains tx hash, view this packet as a "notification"
     // instead of sending the TX directly, we notify our peers
     // so the peer that already have this TX in mempool don't have to read it again
-    // imo: can be useful when the network is spammed by alot of txs
+    // imo: can be useful when the network is spammed by a lot of txs
     TransactionPropagation(PacketWrapper<'a, Hash>),
     BlockPropagation(PacketWrapper<'a, BlockHeader>),
     ChainRequest(PacketWrapper<'a, ChainRequest>),

--- a/xelis_daemon/src/rpc/mod.rs
+++ b/xelis_daemon/src/rpc/mod.rs
@@ -92,11 +92,11 @@ impl<S: Storage> DaemonRpcServer<S> {
             None
         };
 
-        // create the RPC Handler which will register and contains all available methods
+        // Create the RPC Handler which will register and contains all available methods
         let mut rpc_handler = RPCHandler::new(blockchain);
         rpc::register_methods(&mut rpc_handler, !disable_getwork_server);
 
-        // create the default websocket server (support event & rpc methods)
+        // Create the default websocket server (support event & rpc methods)
         let ws = WebSocketServer::new(EventWebSocketHandler::new(rpc_handler));
 
         let server = Arc::new(Self {
@@ -121,7 +121,7 @@ impl<S: Storage> DaemonRpcServer<S> {
             .bind(&bind_address)?
             .run();
 
-            { // save the server handle to be able to stop it later
+            { // Save the server handle to be able to stop it later
                 let handle = http_server.handle();
                 let mut lock = server.handle.lock().await;
                 *lock = Some(handle);
@@ -215,6 +215,6 @@ async fn getwork_endpoint<S: Storage>(server: Data<DaemonRpcServer<S>>, request:
             getwork.add_miner(addr, key, worker).await;
             Ok(response)
         },
-        None => Ok(HttpResponse::NotFound().reason("GetWork server is not enabled").finish()) // getwork server is not started
+        None => Ok(HttpResponse::NotFound().reason("GetWork server is not enabled").finish()) // Getwork server is not started
     }
 }

--- a/xelis_miner/src/config.rs
+++ b/xelis_miner/src/config.rs
@@ -1,2 +1,2 @@
-// daemon address by default when no specified
+// Daemon address by default when none is specified
 pub const DEFAULT_DAEMON_ADDRESS: &str = "127.0.0.1:8080";

--- a/xelis_wallet/src/config.rs
+++ b/xelis_wallet/src/config.rs
@@ -7,7 +7,7 @@ pub const PASSWORD_HASH_SIZE: usize = 32;
 pub const SALT_SIZE: usize = 32;
 pub const KEY_SIZE: usize = 32;
 
-// daemon address by default when no specified
+// Daemon address by default when none is specified
 pub const DEFAULT_DAEMON_ADDRESS: &str = "http://127.0.0.1:8080";
 // Auto reconnect interval in seconds for Network Handler
 pub const AUTO_RECONNECT_INTERVAL: u64 = 5;

--- a/xelis_wallet/src/daemon_api.rs
+++ b/xelis_wallet/src/daemon_api.rs
@@ -76,14 +76,14 @@ impl DaemonAPI {
         &self.client
     }
 
-    // is the websocket connection alive
+    // Is the websocket connection alive
     pub fn is_online(&self) -> bool {
         trace!("is_online");
         self.client.is_online()
     }
 
-    // Disconnect by closing the connection with node RPC
-    // This will only disconnect if there are no more references to the daemon API
+    // Disconnect by closing the connection with node RPC.
+    // This will only disconnect if there are no more references to the daemon API.
     pub async fn disconnect(self: &Arc<Self>) -> Result<bool> {
         trace!("disconnect");
         let count = Arc::strong_count(self);

--- a/xelis_wallet/src/entry.rs
+++ b/xelis_wallet/src/entry.rs
@@ -299,8 +299,8 @@ impl TransactionEntry {
         &mut self.entry
     }
 
-    // Convert to RPC Transaction Entry
-    // This is a necessary step to serialize correctly the public key into an address
+    // Convert to RPC Transaction Entry.
+    // This is a necessary step to serialize correctly the public key into an address.
     pub fn serializable(self, mainnet: bool) -> RPCTransactionEntry {
         RPCTransactionEntry {
             hash: self.hash,

--- a/xelis_wallet/src/main.rs
+++ b/xelis_wallet/src/main.rs
@@ -78,19 +78,19 @@ use {
     anyhow::Error,
 };
 
-// This struct is used to configure the RPC Server
+// This struct is used to configure the RPC Server.
 // In case we want to enable it instead of starting
-// the XSWD Server
+// the XSWD Server.
 #[cfg(feature = "api_server")]
 #[derive(Debug, clap::Args)]
 pub struct RPCConfig {
     /// RPC Server bind address
     #[clap(long)]
     rpc_bind_address: Option<String>,
-    /// username for RPC authentication
+    /// Username for RPC authentication
     #[clap(long)]
     rpc_username: Option<String>,
-    /// password for RPC authentication
+    /// Password for RPC authentication
     #[clap(long)]
     rpc_password: Option<String>
 }
@@ -116,15 +116,15 @@ pub struct Config {
     /// Disable the log file
     #[clap(long)]
     disable_file_logging: bool,
-    /// Disable the log filename date based
+    /// Disable the log filename date based.
     /// If disabled, the log file will be named xelis-wallet.log instead of YYYY-MM-DD.xelis-wallet.log
     #[clap(long)]
     disable_file_log_date_based: bool,
-    /// Disable the usage of colors in log
+    /// Disable the usage of colors in log.
     #[clap(long)]
     disable_log_color: bool,
-    /// Disable terminal interactive mode
-    /// You will not be able to write CLI commands in it or to have an updated prompt
+    /// Disable terminal interactive mode.
+    /// You will not be able to write CLI commands in it or to have an updated prompt.
     #[clap(long)]
     disable_interactive_mode: bool,
     /// Log filename
@@ -146,8 +146,7 @@ pub struct Config {
     /// Set the path for wallet storage to open/create a wallet at this location
     #[clap(long)]
     wallet_path: Option<String>,
-    /// Set the path to use for precomputed tables
-    /// 
+    /// Set the path to use for precomputed tables.
     /// By default, it will be from current directory.
     #[clap(long)]
     precomputed_tables_path: Option<String>,
@@ -168,9 +167,9 @@ pub struct Config {
     #[cfg(feature = "api_server")]
     #[clap(long)]
     enable_xswd: bool,
-    /// Disable the history scan
-    /// This will prevent syncing old TXs/blocks
-    /// Only blocks / transactions caught by the network handler will be stored, not the old ones
+    /// Disable the history scan.
+    /// This will prevent syncing old TXs/blocks.
+    /// Only blocks / transactions caught by the network handler will be stored, not the old ones.
     #[clap(long)]
     disable_history_scan: bool,
     /// Force the wallet to use a stable balance only during transactions creation.
@@ -197,22 +196,21 @@ async fn main() -> Result<()> {
 
     #[cfg(feature = "api_server")]
     {
-        // Sanity check
-        // check that we don't have both server enabled
+        // Sanity check - Check that we don't have both server enabled.
         if config.enable_xswd && config.rpc.rpc_bind_address.is_some() {
             error!("Invalid parameters configuration: RPC Server and XSWD cannot be enabled at the same time");
             return Ok(()); // exit
         }
 
-        // check that username/password is not in param if bind address is not set
+        // Check that username/password is not in param if bind address is not set
         if config.rpc.rpc_bind_address.is_none() && (config.rpc.rpc_password.is_some() || config.rpc.rpc_username.is_some()) {
             error!("Invalid parameters configuration for rpc password and username: RPC Server is not enabled");
             return Ok(())
         }
 
-        // check that username/password is set together if bind address is set
+        // Check that username/password is set together if bind address is set
         if config.rpc.rpc_bind_address.is_some() && config.rpc.rpc_password.is_some() != config.rpc.rpc_username.is_some() {
-            error!("Invalid parameters configuration: usernamd AND password must be provided");
+            error!("Invalid parameters configuration: username AND password must be provided");
             return Ok(())
         }
     }
@@ -221,7 +219,7 @@ async fn main() -> Result<()> {
     command_manager.store_in_context(config.network)?;
 
     if let Some(path) = config.wallet_path {
-        // read password from option or ask him
+        // Read password from option or ask him
         let password = if let Some(password) = config.password {
             password
         } else {
@@ -305,7 +303,7 @@ async fn xswd_handler(mut receiver: UnboundedReceiver<XSWDEvent>, prompt: Sharea
 async fn xswd_handle_request_application(prompt: &ShareablePrompt, app_state: AppStateShared, signed: bool) -> Result<PermissionResult, Error> {
     let mut message = format!("XSWD: Allow application {} ({}) to access your wallet\r\n(Y/N): ", app_state.get_name(), app_state.get_id());
     if signed {
-        message = prompt.colorize_str(Color::BrightYellow, "NOTE: Application authorizaion was already approved previously.\r\n") + &message;
+        message = prompt.colorize_str(Color::BrightYellow, "NOTE: Application authorization was already approved previously.\r\n") + &message;
     }
     let accepted = prompt.read_valid_str_value(prompt.colorize_string(Color::Blue, &message), vec!["y", "n"]).await? == "y";
     if accepted {
@@ -525,7 +523,7 @@ async fn open_wallet(manager: &CommandManager, _: ArgumentManager) -> Result<(),
         Wallet::open(dir, password, *network, precomputed_tables)?
     };
 
-    manager.message("Wallet sucessfully opened");
+    manager.message("Wallet successfully opened");
     apply_config(&wallet, #[cfg(feature = "api_server")] prompt).await;
 
     setup_wallet_command_manager(wallet, manager).await?;
@@ -546,13 +544,13 @@ async fn create_wallet(manager: &CommandManager, _: ArgumentManager) -> Result<(
     }
 
     let dir = format!("{}{}", DIR_PATH, name);
-    // check if it doesn't exists yet
+    // Check if it doesn't exists yet
     if Path::new(&dir).is_dir() {
         manager.message("Wallet already exist with this name!");
         return Ok(())
     }
 
-    // ask and verify password
+    // Ask and verify password
     let password = prompt.read_input("Password: ", true)
         .await.context("Error while reading password")?;
     let confirm_password = prompt.read_input("Confirm Password: ", true)
@@ -570,7 +568,7 @@ async fn create_wallet(manager: &CommandManager, _: ArgumentManager) -> Result<(
         Wallet::create(dir, password, None, *network, precomputed_tables)?
     };
  
-    manager.message("Wallet sucessfully created");
+    manager.message("Wallet successfully created");
     apply_config(&wallet, #[cfg(feature = "api_server")] prompt).await;
 
     // Display the seed in prompt
@@ -607,13 +605,13 @@ async fn recover_wallet(manager: &CommandManager, _: ArgumentManager) -> Result<
     }
 
     let dir = format!("{}{}", DIR_PATH, name);
-    // check if it doesn't exists yet
+    // Check if it doesn't exists yet
     if Path::new(&dir).is_dir() {
         manager.message("Wallet already exist with this name!");
         return Ok(())
     }
 
-    // ask and verify password
+    // Ask and verify password
     let password = prompt.read_input("Password: ", true)
         .await.context("Error while reading password")?;
     let confirm_password = prompt.read_input("Confirm Password: ", true)
@@ -632,7 +630,7 @@ async fn recover_wallet(manager: &CommandManager, _: ArgumentManager) -> Result<
         Wallet::create(dir, password, Some(seed), *network, precomputed_tables)?
     };
 
-    manager.message("Wallet sucessfully recovered");
+    manager.message("Wallet successfully recovered");
     apply_config(&wallet, #[cfg(feature = "api_server")] prompt).await;
 
     setup_wallet_command_manager(wallet, manager).await?;
@@ -667,7 +665,7 @@ async fn transfer(manager: &CommandManager, _: ArgumentManager) -> Result<(), Co
     let context = manager.get_context().lock()?;
     let wallet: &Arc<Wallet> = context.get()?;
 
-    // read address
+    // Read address
     let str_address = prompt.read_input(
         prompt.colorize_str(Color::Green, "Address: "),
         false
@@ -687,7 +685,7 @@ async fn transfer(manager: &CommandManager, _: ArgumentManager) -> Result<(), Co
         (balance, decimals)
     };
 
-    // read amount
+    // Read amount
     let float_amount: f64 = prompt.read(
         prompt.colorize_string(Color::Green, &format!("Amount (max: {}): ", format_coin(max_balance, decimals)))
     ).await.context("Error while reading amount")?;
@@ -727,7 +725,7 @@ async fn transfer_all(manager: &CommandManager, mut args: ArgumentManager) -> Re
     let context = manager.get_context().lock()?;
     let wallet: &Arc<Wallet> = context.get()?;
 
-    // read address
+    // Read address
     let str_address = prompt.read_input(
         prompt.colorize_str(Color::Green, "Address: "),
         false
@@ -804,7 +802,7 @@ async fn burn(manager: &CommandManager, _: ArgumentManager) -> Result<(), Comman
         (balance, decimals)
     };
 
-    // read amount
+    // Read amount
     let float_amount: f64 = prompt.read(
         prompt.colorize_string(Color::Green, &format!("Amount (max: {}): ", format_coin(max_balance, decimals)))
     ).await.context("Error while reading amount")?;
@@ -873,13 +871,13 @@ async fn history(manager: &CommandManager, mut arguments: ArgumentManager) -> Re
     let storage = wallet.get_storage().read().await;
     let mut transactions = storage.get_transactions()?;
 
-    // if we don't have any txs, no need proceed further
+    // If we don't have any txs, no need proceed further
     if transactions.is_empty() {
         manager.message("No transactions available");
         return Ok(())
     }
 
-    // desc ordered
+    // Desc ordered
     transactions.sort_by(|a, b| b.get_topoheight().cmp(&a.get_topoheight()));
     let mut max_pages = transactions.len() / TXS_PER_PAGE;
     if transactions.len() % TXS_PER_PAGE != 0 {
@@ -955,7 +953,7 @@ async fn seed(manager: &CommandManager, mut arguments: ArgumentManager) -> Resul
 
     let password = prompt.read_input("Password: ", true)
         .await.context("Error while reading password")?;
-    // check if password is valid
+    // Check if password is valid
     wallet.is_valid_password(password).await?;
 
     let language = if arguments.has_argument("language") {
@@ -1059,7 +1057,7 @@ async fn start_xswd(manager: &CommandManager, _: ArgumentManager) -> Result<(), 
     Ok(())
 }
 
-// broadcast tx if possible
+// Broadcast TX if possible
 // submit_transaction increase the local nonce in storage in case of success
 async fn broadcast_tx(wallet: &Wallet, manager: &CommandManager, tx: Transaction) {
     let tx_hash = tx.hash();

--- a/xelis_wallet/src/mnemonics/mod.rs
+++ b/xelis_wallet/src/mnemonics/mod.rs
@@ -33,7 +33,7 @@ lazy_static! {
 
 pub struct Language<'a> {
     name: &'a str,
-    prefix_length: usize, // number of utf-8 chars to use for checksum
+    prefix_length: usize, // Number of utf-8 chars to use for checksum
     words: [&'a str; WORDS_LIST]
 }
 
@@ -65,25 +65,25 @@ fn verify_checksum(words: &Vec<String>, prefix_len: usize) -> Result<bool> {
 
 fn find_indices(words: &Vec<String>) -> Result<Option<(Vec<usize>, usize)>> {
     'main: for (i, language) in LANGUAGES.iter().enumerate() {
-        // this map is used to store the indices of the words in the language
+        // This map is used to store the indices of the words in the language
         let mut language_words: HashMap<&str, usize> = HashMap::with_capacity(WORDS_LIST);
-        // build the map
+        // Build the map
         for (j, word) in language.words.iter().enumerate() {
             language_words.insert(word, j);
         }
 
-        // find the indices of the words
+        // Find the indices of the words
         let mut indices = Vec::new();
         for word in words.iter() {
             if let Some(index) = language_words.get(word.as_str()) {
                 indices.push(*index);
             } else {
-                // incorrect language for this word, try the next one
+                // Incorrect language for this word, try the next one
                 continue 'main;
             }
         }
 
-        // we were able to build the indices, now verify checksum
+        // We were able to build the indices, now verify checksum
         if !verify_checksum(&words, language.prefix_length)? {
             return Err(anyhow!("Invalid checksum for seed"));
         }
@@ -93,7 +93,7 @@ fn find_indices(words: &Vec<String>) -> Result<Option<(Vec<usize>, usize)>> {
     Ok(None)
 }
 
-// convert a words list to a Private Key (32 bytes)
+// Convert a words list to a Private Key (32 bytes)
 pub fn words_to_key(words: &Vec<String>) -> Result<PrivateKey> {
     if words.len() != SEED_LENGTH + 1 {
         return Err(anyhow!("Invalid number of words"));

--- a/xelis_wallet/src/precomputed_tables/mod.rs
+++ b/xelis_wallet/src/precomputed_tables/mod.rs
@@ -31,8 +31,8 @@ use std::sync::Arc;
 use log::debug;
 use xelis_common::crypto::ecdlp;
 
-// This is a 32 bytes aligned struct
-// It is necessary for the precomputed tables points
+// This is a 32 bytes aligned struct.
+// It is necessary for the precomputed tables points.
 #[derive(bytemuck::Pod, bytemuck::Zeroable, Copy, Clone)]
 #[repr(C, align(32))]
 struct Bytes32Alignment([u8; 32]);

--- a/xelis_wallet/src/precomputed_tables/native.rs
+++ b/xelis_wallet/src/precomputed_tables/native.rs
@@ -6,8 +6,8 @@ use xelis_common::crypto::ecdlp;
 
 use super::{PrecomputedTables, PrecomputedTablesShared};
 
-// This will read from file if exists, or generate and store it in file
-// This must be call only one time, and can be cloned to be shared through differents wallets
+// This will read from file if it exists, or generate and store it in file.
+// This must be called only one time, and can be cloned to be shared through different wallets.
 pub fn read_or_generate_precomputed_tables<P: ecdlp::ProgressTableGenerationReportFunction>(path: Option<String>, progress_report: P, l1: usize) -> Result<PrecomputedTablesShared> {
     let mut precomputed_tables = PrecomputedTables::new(l1);
 

--- a/xelis_wallet/src/precomputed_tables/web.rs
+++ b/xelis_wallet/src/precomputed_tables/web.rs
@@ -5,13 +5,13 @@ use xelis_common::crypto::ecdlp;
 
 use super::{PrecomputedTables, PrecomputedTablesShared};
 
-// Precomputed tables is too heavy to be stored in local Storage, and generating it on the fly would be too slow
-// So we will generate it on the server and store it in a file, and then we will read it from the file
+// The precomputed tables is too heavy to be stored in local Storage, and generating it on the fly would be too slow.
+// So we will generate it on the server and store it in a file, and then we will read it from the file.
 pub fn read_or_generate_precomputed_tables<P: ecdlp::ProgressTableGenerationReportFunction>(_: Option<String>, _: P, l1: usize) -> Result<PrecomputedTablesShared> {
     let mut precomputed_tables = PrecomputedTables::new(l1);    
     let bytes = include_bytes!("precomputed_tables.bin");
     // We are forced to re-allocate the precomputed tables instead of using the reference
-    // to have the correct alignment in memory
+    // to have the correct alignment in memory.
     precomputed_tables.get_mut().copy_from_slice(bytes);
     // let precomputed_tables = PrecomputedTables::with_bytes(bytes, l1);
     Ok(Arc::new(precomputed_tables))

--- a/xelis_wallet/src/storage/backend/web.rs
+++ b/xelis_wallet/src/storage/backend/web.rs
@@ -118,7 +118,7 @@ pub struct Db {
 )))]
 #[derive(Debug, Error)]
 pub enum DbError {
-    #[error("An error occured on the database")]
+    #[error("An error occurred on the database")]
     Poisoned
 }
 
@@ -129,7 +129,7 @@ pub enum DbError {
 ))]
 #[derive(Debug, Error)]
 pub enum DbError {
-    #[error("An error occured on the database")]
+    #[error("An error occurred on the database")]
     Poisoned,
     #[error("Cannot access to the window object")]
     Window,
@@ -435,7 +435,7 @@ impl InnerTree {
     }
 }
 
-// TODO: rework this
+// TODO: rework this.
 // A reference to all the entries in a `Tree`.
 // So, even if it get changed while we iter, we still have a reference to the old entries.
 pub struct Iter {

--- a/xelis_wallet/src/storage/mod.rs
+++ b/xelis_wallet/src/storage/mod.rs
@@ -50,7 +50,7 @@ use crate::{
 use self::backend::{Db, Tree};
 use log::{trace, debug, error};
 
-// keys used to retrieve from storage
+// Keys used to retrieve from storage
 const NONCE_KEY: &[u8] = b"NONCE";
 const SALT_KEY: &[u8] = b"SALT";
 // Password + salt is necessary to decrypt master key
@@ -59,10 +59,10 @@ const PASSWORD_SALT_KEY: &[u8] = b"PSALT";
 const MASTER_KEY: &[u8] = b"MKEY";
 const PRIVATE_KEY: &[u8] = b"PKEY";
 
-// const used for online mode
-// represent the daemon topoheight
+// Const used for online mode.
+// Represent the daemon topoheight.
 const TOPOHEIGHT_KEY: &[u8] = b"TOPH";
-// represent the daemon top block hash
+// Represent the daemon top block hash
 const TOP_BLOCK_HASH_KEY: &[u8] = b"TOPBH";
 const NETWORK: &[u8] = b"NET";
 // Last coinbase reward topoheight
@@ -120,35 +120,35 @@ pub struct TxCache {
 
 // Implement an encrypted storage system 
 pub struct EncryptedStorage {
-    // cipher used to encrypt/decrypt/hash data
+    // Cipher used to encrypt/decrypt/hash data
     cipher: Cipher,
     // All transactions where this wallet is part of
     transactions: Tree,
-    // balances for each asset
+    // Balances for each asset
     balances: Tree,
-    // extra data (network, topoheight, etc)
+    // Extra data (network, topoheight, etc)
     extra: Tree,
-    // all assets tracked by the wallet
+    // All assets tracked by the wallet
     assets: Tree,
-    // This tree is used to store all topoheight where a change in the wallet occured
+    // This tree is used to store all topoheight where a change in the wallet occurred
     changes_topoheight: Tree,
     // The inner storage
     inner: Storage,
     // Caches
     balances_cache: Mutex<LruCache<Hash, Balance>>,
-    // this cache is used to store unconfirmed balances
-    // it is used to store the balance before the transaction is confirmed
-    // so we can build several txs without having to wait for the confirmation
-    // We store it in a VecDeque so for each TX we have an entry and can just retrieve it
+    // This cache is used to store unconfirmed balances.
+    // It is used to store the balance before the transaction is confirmed
+    // so we can build several txs without having to wait for the confirmation.
+    // We store it in a VecDeque so for each TX we have an entry and can just retrieve it.
     unconfirmed_balances_cache: Mutex<HashMap<Hash, VecDeque<Balance>>>,
     tx_cache: Option<TxCache>,
     // Cache for the assets with their decimals
     assets_cache: Mutex<LruCache<Hash, u8>>,
     // Cache for the synced topoheight
     synced_topoheight: Option<u64>,
-    // Topoheight of the last coinbase reward
+    // Topoheight of the last coinbase reward.
     // This is used to determine if we should
-    // use a stable balance or not
+    // use a stable balance or not.
     last_coinbase_reward_topoheight: Option<u64>,
 }
 
@@ -219,7 +219,7 @@ impl EncryptedStorage {
         self.internal_load(tree, &hashed_key)
     }
 
-    // Because we can't predict the nonce used for encryption, we make it determistic
+    // Because we can't predict the nonce used for encryption, we make it deterministic
     fn create_encrypted_key(&self, key: &[u8]) -> Result<Vec<u8>> {
         trace!("create encrypted key");
         // the hashed key is salted so its unique and can't be recover/bruteforced
@@ -233,15 +233,15 @@ impl EncryptedStorage {
         Ok(key)
     }
 
-    // load from disk using an encrypted key, decrypt the value and deserialize it
+    // Load from disk using an encrypted key, decrypt the value and deserialize it
     fn load_from_disk_with_encrypted_key<V: Serializer>(&self, tree: &Tree, key: &[u8]) -> Result<V> {
         trace!("load from disk with encrypted key");
         let encrypted_key = self.create_encrypted_key(key)?;
         self.internal_load(tree, &encrypted_key)
     }
 
-    // Encrypt key, encrypt data and then save to disk
-    // We encrypt instead of hashing to be able to retrieve the key
+    // Encrypt key, encrypt data and then save to disk.
+    // We encrypt instead of hashing to be able to retrieve the key.
     fn save_to_disk_with_encrypted_key(&self, tree: &Tree, key: &[u8], value: &[u8]) -> Result<()> {
         trace!("save to disk with encrypted key");
         let encrypted_key = self.create_encrypted_key(key)?;
@@ -250,7 +250,7 @@ impl EncryptedStorage {
         Ok(())
     }
 
-    // hash key, encrypt data and then save to disk 
+    // Hash key, encrypt data and then save to disk 
     fn save_to_disk(&self, tree: &Tree, key: &[u8], value: &[u8]) -> Result<()> {
         trace!("save to disk");
         let hashed_key = self.cipher.hash_key(key);
@@ -258,7 +258,7 @@ impl EncryptedStorage {
         Ok(())
     }
 
-    // hash key, encrypt data and then save to disk 
+    // Hash key, encrypt data and then save to disk 
     fn delete_from_disk(&self, tree: &Tree, key: &[u8]) -> Result<()> {
         trace!("delete from disk");
         let hashed_key = self.cipher.hash_key(key);
@@ -266,7 +266,7 @@ impl EncryptedStorage {
         Ok(())
     }
 
-    // hash key, encrypt data and then save to disk 
+    // Hash key, encrypt data and then save to disk 
     fn delete_from_disk_with_encrypted_key(&self, tree: &Tree, key: &[u8]) -> Result<()> {
         trace!("delete from disk with encrypted key");
         let encrypted_key = self.create_encrypted_key(key)?;
@@ -326,8 +326,8 @@ impl EncryptedStorage {
         self.contains_encrypted_data(&tree, &key.to_bytes())
     }
 
-    // Search all entries with requested query_key/query_value
-    // It has to go through the whole tree elements, decrypt each key/value and verify them against the query filter set
+    // Search all entries with requested query_key/query_value.
+    // It has to go through the whole tree elements, decrypt each key/value and verify them against the query filter set.
     pub fn query_db(&self, tree: impl Into<String>, query_key: Option<Query>, query_value: Option<Query>, return_on_first: bool) -> Result<QueryResult> {
         trace!("query db");
         let tree = self.get_custom_tree(tree)?;
@@ -401,8 +401,8 @@ impl EncryptedStorage {
         Ok(keys)
     }
 
-    // Count entries from a tree
-    // A query is possible to filter on keys
+    // Count entries from a tree.
+    // A query is possible to filter on keys.
     pub fn count_custom_tree_entries(&self, tree: &String, query_key: &Option<Query>, query_value: &Option<Query>) -> Result<usize> {
         trace!("count custom tree entries");
         let tree = self.get_custom_tree(tree)?;
@@ -438,8 +438,8 @@ impl EncryptedStorage {
         Ok(count)
     }
 
-    // this function is specific because we save the key in encrypted form (and not hashed as others)
-    // returns all saved assets
+    // This function is specific because we save the key in encrypted form (and not hashed as others).
+    // Returns all saved assets.
     pub async fn get_assets(&self) -> Result<HashSet<Hash>> {
         trace!("get assets");
         let mut cache = self.assets_cache.lock().await;
@@ -510,7 +510,7 @@ impl EncryptedStorage {
         self.contains_encrypted_data(&self.assets, asset.as_bytes())
     }
 
-    // save asset with its corresponding decimals
+    // Save asset with its corresponding decimals
     pub async fn add_asset(&mut self, asset: &Hash, decimals: u8) -> Result<()> {
         trace!("add asset");
         if self.contains_asset(asset).await? {
@@ -625,11 +625,11 @@ impl EncryptedStorage {
     // Set the balance for this asset
     pub async fn set_balance_for(&mut self, asset: &Hash, mut balance: Balance) -> Result<()> {
         trace!("set balance for {}", asset);
-        // Clear the cache of all outdated balances
-        // for this, we simply go through all versions available and delete them all until we find the one we are looking for
-        // The unconfirmed balances cache may not work during front running
+        // Clear the cache of all outdated balances.
+        // For this, we simply go through all versions available and delete them all until we find the one we are looking for.
+        // The unconfirmed balances cache may not work during front running.
         // As we only scan the final balances for each asset, if we get any incoming TX, compressed balance
-        // will be different and we will not be able to find the unconfirmed balance
+        // will be different and we will not be able to find the unconfirmed balance.
         {
             let mut cache = self.unconfirmed_balances_cache.lock().await;
             let mut delete_entry = false;
@@ -674,14 +674,14 @@ impl EncryptedStorage {
         self.load_from_disk(&self.transactions, hash.as_bytes())
     }
 
-    // read whole disk and returns all transactions
+    // Read whole disk and returns all transactions
     pub fn get_transactions(&self) -> Result<Vec<TransactionEntry>> {
         trace!("get transactions");
         self.get_filtered_transactions(None, None, None, true, true, true, true, None)
     }
 
-    // delete all transactions above the specified topoheight
-    // This will go through each transaction, deserialize it, check topoheight, and delete it if required
+    // Delete all transactions above the specified topoheight.
+    // This will go through each transaction, deserialize it, check topoheight, and delete it if required.
     pub fn delete_transactions_above_topoheight(&mut self, topoheight: u64) -> Result<()> {
         trace!("delete transactions above topoheight {}", topoheight);
         for el in self.transactions.iter().values() {
@@ -695,9 +695,9 @@ impl EncryptedStorage {
         Ok(())
     }
 
-    // delete all transactions at the specified topoheight
-    // This will go through each transaction, deserialize it, check topoheight, and delete it if required
-    // Maybe we can optimize it by keeping a lookuptable of topoheight -> txs ?
+    // Delete all transactions at the specified topoheight.
+    // This will go through each transaction, deserialize it, check topoheight, and delete it if required.
+    // Maybe we can optimize it by keeping a lookup table of topoheight -> TXs?
     pub fn delete_transactions_at_topoheight(&mut self, topoheight: u64) -> Result<()> {
         trace!("delete transactions at topoheight {}", topoheight);
         for el in self.transactions.iter().values() {
@@ -812,7 +812,7 @@ impl EncryptedStorage {
         self.clear_tx_cache();
     }
 
-    // Delete tx cache
+    // Delete TX cache
     pub fn clear_tx_cache(&mut self) {
         trace!("clear tx cache");
         self.tx_cache = None;
@@ -826,9 +826,9 @@ impl EncryptedStorage {
         Ok(())
     }
 
-    // Save the transaction with its TX hash as key
-    // We hash the hash of the TX to use it as a key to not let anyone being able to see txs saved on disk
-    // with no access to the decrypted master key
+    // Save the transaction with its TX hash as key.
+    // We hash the hash of the TX to use it as a key to not let anyone being able to see TXs saved on disk
+    // without access to the decrypted master key.
     pub fn save_transaction(&mut self, hash: &Hash, transaction: &TransactionEntry) -> Result<()> {
         trace!("save transaction {}", hash);
 
@@ -852,8 +852,8 @@ impl EncryptedStorage {
         self.load_from_disk(&self.extra, NONCE_KEY)
     }
 
-    // Get the unconfirmed nonce to use to build ordered TXs
-    // It will fallback to the real nonce if not set
+    // Get the unconfirmed nonce to use to build ordered TXs.
+    // It will fallback to the real nonce if not set.
     pub fn get_unconfirmed_nonce(&self) -> u64 {
         trace!("get unconfirmed nonce");
         self.tx_cache.as_ref().map(|c| c.nonce).unwrap_or_else(|| self.get_nonce().unwrap_or(0))
@@ -871,15 +871,15 @@ impl EncryptedStorage {
         self.tx_cache.as_ref()
     }
 
-    // Set the new nonce used to create new transactions
+    // Set the new nonce used to create new transactions.
     // If the unconfirmed nonce is lower than the new nonce, we reset it
     pub fn set_nonce(&mut self, nonce: u64) -> Result<()> {
         trace!("set nonce to {}", nonce);
         self.save_to_disk(&self.extra, NONCE_KEY, &nonce.to_be_bytes())
     }
 
-    // Store the last coinbase reward topoheight
-    // This is used to determine if we should use a stable balance or not
+    // Store the last coinbase reward topoheight.
+    // This is used to determine if we should use a stable balance or not.
     pub fn set_last_coinbase_reward_topoheight(&mut self, topoheight: Option<u64>) -> Result<()> {
         trace!("set last coinbase reward topoheight to {:?}", topoheight);
         if let Some(topoheight) = topoheight {
@@ -987,7 +987,7 @@ impl EncryptedStorage {
         self.contains_data(&self.extra, NETWORK)
     }
 
-    // Add a topoheight where a change occured
+    // Add a topoheight where a change occurred
     pub fn add_topoheight_to_changes(&mut self, topoheight: u64, block_hash: &Hash) -> Result<()> {
         trace!("add topoheight to changes: {} at {}", topoheight, block_hash);
         self.save_to_disk_with_encrypted_key(&self.changes_topoheight, &topoheight.to_be_bytes(), block_hash.as_bytes())
@@ -1005,8 +1005,8 @@ impl EncryptedStorage {
         self.contains_encrypted_data(&self.changes_topoheight, &topoheight.to_be_bytes())
     }
 
-    // Delete all changes above topoheight
-    // This will returns true if a changes was deleted
+    // Delete all changes above topoheight.
+    // This will returns true if a changes was deleted.
     pub fn delete_changes_above_topoheight(&mut self, topoheight: u64) -> Result<bool> {
         trace!("delete changes above topoheight {}", topoheight);
         let mut deleted = false;
@@ -1024,8 +1024,8 @@ impl EncryptedStorage {
         Ok(deleted)
     }
 
-    // Delete changes at topoheight
-    // This will returns true if a changes was deleted
+    // Delete changes at topoheight.
+    // This will returns true if a changes was deleted.
     pub fn delete_changes_at_topoheight(&mut self, topoheight: u64) -> Result<()> {
         trace!("delete changes at topoheight {}", topoheight);
         self.delete_from_disk_with_encrypted_key(&self.changes_topoheight, &topoheight.to_be_bytes())?;
@@ -1070,15 +1070,15 @@ impl Storage {
         })
     }
 
-    // save the encrypted form of the master key
-    // it can only be decrypted using the password-based key
+    // Save the encrypted form of the master key.
+    // It can only be decrypted using the password-based key.
     pub fn set_encrypted_master_key(&mut self, encrypted_key: &[u8]) -> Result<()> {
         trace!("set encrypted master key");
         self.db.insert(MASTER_KEY, encrypted_key)?;
         Ok(())
     }
 
-    // retrieve the encrypted form of the master key
+    // Retrieve the encrypted form of the master key
     pub fn get_encrypted_master_key(&self) -> Result<Vec<u8>> {
         trace!("get encrypted master key");
         match self.db.get(MASTER_KEY)? {
@@ -1091,14 +1091,14 @@ impl Storage {
         }
     }
 
-    // set password salt used to derive the password-based key
+    // Set password salt used to derive the password-based key
     pub fn set_password_salt(&mut self, salt: &[u8]) -> Result<()> {
         trace!("set password salt");
         self.db.insert(PASSWORD_SALT_KEY, salt)?;
         Ok(())
     }
 
-    // retrieve password salt used to derive the password-based key
+    // Retrieve password salt used to derive the password-based key
     pub fn get_password_salt(&self) -> Result<[u8; SALT_SIZE]> {
         trace!("get password salt");
         let mut salt: [u8; SALT_SIZE] = [0; SALT_SIZE];
@@ -1118,7 +1118,7 @@ impl Storage {
         Ok(salt)
     }
 
-    // get the salt used for encrypted storage
+    // Get the salt used for encrypted storage
     pub fn get_encrypted_storage_salt(&self) -> Result<Vec<u8>> {
         trace!("get encrypted storage salt");
         let values = self.db.get(SALT_KEY)?.context("encrypted salt for storage was not found")?;
@@ -1128,7 +1128,7 @@ impl Storage {
         Ok(encrypted_salt)
     }
 
-    // set the salt used for encrypted storage
+    // Set the salt used for encrypted storage
     pub fn set_encrypted_storage_salt(&mut self, salt: &[u8]) -> Result<()> {
         trace!("set encrypted storage salt");
         self.db.insert(SALT_KEY, salt)?;

--- a/xelis_wallet/src/transaction_builder.rs
+++ b/xelis_wallet/src/transaction_builder.rs
@@ -7,11 +7,11 @@ use xelis_common::{
 };
 use crate::{error::WalletError, storage::{Balance, EncryptedStorage, TxCache}};
 
-// State used to estimate fees for a transaction
+// State used to estimate fees for a transaction.
 // Because fees can be higher if a destination account is not registered
-// We need to give this information during the estimation of fees
+// we need to give this information during the estimation of fees.
 pub struct EstimateFeesState {
-    // this is containing the registered keys that we are aware of
+    // This is containing the registered keys that we are aware of
     registered_keys: HashSet<PublicKey>
 }
 
@@ -39,8 +39,8 @@ impl FeeHelper for EstimateFeesState {
     }
 }
 
-// State used to build a transaction
-// It contains the balances of the wallet and the registered keys
+// State used to build a transaction.
+// It contains the balances of the wallet and the registered keys.
 pub struct TransactionBuilderState {
     inner: EstimateFeesState,
     mainnet: bool,


### PR DESCRIPTION
## Description

I decided to fix any typos, grammar issues, or unclear comments as well as standardize the format of the comments while reading through the repo to gain a better understanding of how everything works. Nearly all changes are to comments only, however, there is one variable name that was renamed due to a typo. 

All comments now start with a capital and any multi-line comments have better punctuation to be more easily read. This brings the comments format closer to what the rust foundation recommends and improves the overall readability. I tried to keep the content of each comment as close to the original as I could, however, there were a few comments that were very difficult to read and those were heavily changed.

## Type of change

Please select the right one.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Which part is impacted ?

  - [x] Daemon
  - [x] Wallet
  - [x] Miner
  - [x] Misc (documentation, comments, text...)

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings