### PR TITLE
v1.14.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target/
 mainnet/
 testnet/
 dev/
+peerlist-*/
 .vscode/
 wallets/
 peerlist-*.json

--- a/API.md
+++ b/API.md
@@ -3158,7 +3158,7 @@ No parameters
 }
 ```
 
-#### Get Topo Height
+#### Get Pruned Topo Height
 Retrieve the pruned topoheight if the node has a pruned chain.
 Otherwise, returns `null` as value.
 

--- a/API.md
+++ b/API.md
@@ -3158,6 +3158,33 @@ No parameters
 }
 ```
 
+#### Get Topo Height
+Retrieve the pruned topoheight if the node has a pruned chain.
+Otherwise, returns `null` as value.
+
+##### Method `get_pruned_topoheight`
+
+##### Parameters
+No parameters
+
+##### Request
+```json
+{
+	"jsonrpc": "2.0",
+	"method": "get_pruned_topoheight",
+	"id": 1
+}
+```
+
+##### Response
+```json
+{
+	"id": 1,
+	"jsonrpc": "2.0",
+	"result": null
+}
+```
+
 #### Get Stable Height
 Retrieve current stable height of the chain.
 

--- a/API.md
+++ b/API.md
@@ -11162,7 +11162,6 @@ Returned fees are in atomic units.
 }
 ```
 
-
 #### Is Online
 Determine if the wallet is connected to a node or not (offline / online mode).
 
@@ -11186,6 +11185,50 @@ No parameter
 	"id": 1,
 	"jsonrpc": "2.0",
 	"result": true
+}
+```
+
+#### Network Info
+Fetch all information about the current node to which the wallet is connected to.
+
+##### Method `network_info`
+
+##### Parameters
+No parameter
+
+##### Request
+```json
+{
+	"jsonrpc": "2.0",
+	"method": "network_info",
+	"id": 1
+}
+```
+
+##### Response
+```json
+{
+    "id": 1,
+    "jsonrpc": "2.0",
+    "result": {
+        "average_block_time": 15954,
+        "block_reward": 137924147,
+        "block_time_target": 15000,
+        "circulating_supply": 104512595148870,
+        "connected_to": "ws://127.0.0.1:8080/json_rpc",
+        "dev_reward": 13792414,
+        "difficulty": "107844053400",
+        "height": 725025,
+        "maximum_supply": 1840000000000000,
+        "mempool_size": 0,
+        "miner_reward": 124131733,
+        "network": "Mainnet",
+        "pruned_topoheight": null,
+        "stableheight": 725017,
+        "top_block_hash": "1914802b64b28386adc37927081beb6ac4677b6f85ee2149f7a143339c99d309",
+        "topoheight": 761761,
+        "version": "1.13.4-d33986a"
+    }
 }
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ This file contains all the changelogs to ensure that changes can be tracked and 
 
 To see the full history and exact changes, please refer to the commits history directly.
 
+## v1.14.0
+
+Moving to 1.14.0 due to breaking changes in peerlist storage.
+
+Common:
+- add new struct for `network_info` rpc method
+- clean up in ws json rpc client
+
+Daemon:
+- add `get_pruned_topoheight` rpc method
+- P2P peerlist is now backed by a DB instead of a traditional JSON file. (Reduce memory usage, and better I/O operations)
+-  add `show_peerlist` cli command
+- paginate few CLI commands
+- don't keep Peer instance in chain sync task, but its priority flag & id only.
+
+Wallet:
+- `network_info` rpc method added
+- fix `force-stable-balance` CLI option
+- add `clear_tx_cache` cli command
+- fix blockDAG reorg resync of transactions
+- support anonymous browsing for web wallet (no access to directory feature)
+
+
 ## v1.13.4
 
 Bug fixes for nodes with less than 2GB of ram, and for nodes having reorg issues.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-This  file  contains  all  the  changelogs  to  ensure  that  changes  can  be  tracked  and  to  provide  a  summary  for  interested  parties.
+This file contains all the changelogs to ensure that changes can be tracked and to provide a summary for interested parties.
 
 To see the full history and exact changes, please refer to the commits history directly.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3455,7 +3455,7 @@ dependencies = [
 
 [[package]]
 name = "xelis_common"
-version = "1.13.4"
+version = "1.14.0"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -3498,7 +3498,7 @@ dependencies = [
 
 [[package]]
 name = "xelis_daemon"
-version = "1.13.4"
+version = "1.14.0"
 dependencies = [
  "actix",
  "actix-web",
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "xelis_miner"
-version = "1.13.4"
+version = "1.14.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3548,7 +3548,7 @@ dependencies = [
 
 [[package]]
 name = "xelis_wallet"
-version = "1.13.4"
+version = "1.14.0"
 dependencies = [
  "actix",
  "actix-web",

--- a/xelis_common/Cargo.toml
+++ b/xelis_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xelis_common"
-version = "1.13.4"
+version = "1.14.0"
 edition = "2021"
 authors = ["Slixe <slixeprivate@gmail.com>"]
 build = "build.rs"

--- a/xelis_common/src/api/wallet.rs
+++ b/xelis_common/src/api/wallet.rs
@@ -15,7 +15,8 @@ use super::{
     DataValue,
     query::Query,
     default_false_value,
-    default_true_value
+    default_true_value,
+    daemon
 };
 
 #[derive(Serialize, Deserialize)]
@@ -114,6 +115,13 @@ pub struct SetOnlineModeParams {
     pub daemon_address: String,
     #[serde(default = "default_false_value")]
     pub auto_reconnect: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct NetworkInfoResult {
+    #[serde(flatten)]
+    pub inner: daemon::GetInfoResult,
+    pub connected_to: String,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/xelis_common/src/json_rpc/websocket.rs
+++ b/xelis_common/src/json_rpc/websocket.rs
@@ -59,8 +59,8 @@ impl<T: DeserializeOwned> EventReceiver<T> {
         // If we lagged behind, we need to catch up
         while let Err(e) = res {
             match e {
-                broadcast::error::RecvError::Lagged(_) => {
-                    error!("EventReceiver lagged behind, catching up...");
+                broadcast::error::RecvError::Lagged(i) => {
+                    error!("EventReceiver lagged {i} behind, catching up...");
                     res = self.inner.recv().await;
                 }
                 e => return Err(e.into())

--- a/xelis_common/src/json_rpc/websocket.rs
+++ b/xelis_common/src/json_rpc/websocket.rs
@@ -114,15 +114,11 @@ pub struct WebSocketJsonRPCClientImpl<E: Serialize + Hash + Eq + Send + Sync + C
 pub const DEFAULT_AUTO_RECONNECT: Duration = Duration::from_secs(5);
 
 impl<E: Serialize + Hash + Eq + Send + Sync + Clone + std::fmt::Debug + 'static> WebSocketJsonRPCClientImpl<E> {
-    async fn connect_to(target: &String) -> Result<WebSocketStream, JsonRPCError> {
-        let ws = connect(target).await?;
 
-        Ok(ws)
-    }
-
+    // Create a new WebSocketJsonRPCClient with the target address
     pub async fn new(mut target: String) -> Result<WebSocketJsonRPCClient<E>, JsonRPCError> {
         target = sanitize_daemon_address(target.as_str());
-        let ws = Self::connect_to(&target).await?;
+        let ws = connect(&target).await?;
 
         let (sender, receiver) = mpsc::channel(64);
         let client = Arc::new(WebSocketJsonRPCClientImpl {
@@ -147,6 +143,11 @@ impl<E: Serialize + Hash + Eq + Send + Sync + Clone + std::fmt::Debug + 'static>
         }
 
         Ok(client)
+    }
+
+    // Get the target address
+    pub fn get_target(&self) -> &str {
+        &self.target
     }
 
     // Generate a new ID for a JSON-RPC request
@@ -280,7 +281,7 @@ impl<E: Serialize + Hash + Eq + Send + Sync + Clone + std::fmt::Debug + 'static>
             return Ok(false)
         }
 
-        let ws = Self::connect_to(&self.target).await?;
+        let ws = connect(&self.target).await?;
         {
             let mut lock = self.background_task.lock().await;
             if let Some(handle) = lock.take() {
@@ -359,7 +360,7 @@ impl<E: Serialize + Hash + Eq + Send + Sync + Clone + std::fmt::Debug + 'static>
                     debug!("Reconnecting to the server in {} seconds...", auto_reconnect.as_secs());
                     sleep(auto_reconnect).await;
 
-                    match Self::connect_to(&zelf.target).await {
+                    match connect(&zelf.target).await {
                         Ok(websocket) => {
                             ws = Some(websocket);
 

--- a/xelis_daemon/Cargo.toml
+++ b/xelis_daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xelis_daemon"
-version = "1.13.4"
+version = "1.14.0"
 edition = "2021"
 authors = ["Slixe <slixeprivate@gmail.com>"]
 

--- a/xelis_daemon/src/main.rs
+++ b/xelis_daemon/src/main.rs
@@ -193,7 +193,7 @@ async fn run_prompt<S: Storage>(prompt: ShareablePrompt, blockchain: Arc<Blockch
     command_manager.add_command(Command::with_optional_arguments("list_miners", "List all miners connected", vec![Arg::new("page", ArgType::Number)], CommandHandler::Async(async_handler!(list_miners::<S>))))?;
     command_manager.add_command(Command::with_optional_arguments("list_peers", "List all peers connected", vec![Arg::new("page", ArgType::Number)], CommandHandler::Async(async_handler!(list_peers::<S>))))?;
     command_manager.add_command(Command::with_optional_arguments("list_assets", "List all assets registered on chain", vec![Arg::new("page", ArgType::Number)], CommandHandler::Async(async_handler!(list_assets::<S>))))?;
-    command_manager.add_command(Command::with_optional_arguments("show_stored_peerlist", "Show the stored peerlist", vec![Arg::new("page", ArgType::Number)], CommandHandler::Async(async_handler!(show_stored_peerlist::<S>))))?;
+    command_manager.add_command(Command::with_optional_arguments("show_peerlist", "Show the stored peerlist", vec![Arg::new("page", ArgType::Number)], CommandHandler::Async(async_handler!(show_stored_peerlist::<S>))))?;
     command_manager.add_command(Command::with_arguments("show_balance", "Show balance of an address", vec![], vec![Arg::new("history", ArgType::Number)], CommandHandler::Async(async_handler!(show_balance::<S>))))?;
     command_manager.add_command(Command::with_required_arguments("print_block", "Print block in json format", vec![Arg::new("hash", ArgType::Hash)], CommandHandler::Async(async_handler!(print_block::<S>))))?;
     command_manager.add_command(Command::new("top_block", "Print top block", CommandHandler::Async(async_handler!(top_block::<S>))))?;
@@ -603,7 +603,7 @@ async fn show_stored_peerlist<S: Storage>(manager: &CommandManager, mut argument
     match blockchain.get_p2p().read().await.as_ref() {
         Some(p2p) => {
             let peer_list = p2p.get_peer_list();
-            let peerlist: Vec<_> = peer_list.get_stored_peers().collect::<Result<Vec<_>, _>>().context("Error while retrieving stored peerlist")?;
+            let peerlist: Vec<_> = peer_list.get_peerlist_entries().collect::<Result<Vec<_>, _>>().context("Error while retrieving stored peerlist")?;
             let mut max_pages = peerlist.len() / ELEMENTS_PER_PAGE;
             if peerlist.len() % ELEMENTS_PER_PAGE != 0 {
                 max_pages += 1;

--- a/xelis_daemon/src/main.rs
+++ b/xelis_daemon/src/main.rs
@@ -492,6 +492,11 @@ async fn list_miners<S: Storage>(manager: &CommandManager, mut arguments: Argume
         Some(rpc) => match rpc.getwork_server() {
             Some(getwork) => {
                 let miners = getwork.get_miners().lock().await;
+                if miners.is_empty() {
+                    manager.message("No miners connected");
+                    return Ok(());
+                }
+
                 let mut max_pages = miners.len() / ELEMENTS_PER_PAGE;
                 if miners.len() % ELEMENTS_PER_PAGE != 0 {
                     max_pages += 1;
@@ -535,6 +540,11 @@ async fn list_peers<S: Storage>(manager: &CommandManager, mut arguments: Argumen
         Some(p2p) => {
             let peer_list = p2p.get_peer_list();
             let peers = peer_list.get_peers().read().await;
+            if peers.is_empty() {
+                manager.message("No peers connected");
+                return Ok(());
+            }
+
             let mut max_pages = peers.len() / ELEMENTS_PER_PAGE;
             if peers.len() % ELEMENTS_PER_PAGE != 0 {
                 max_pages += 1;
@@ -571,6 +581,11 @@ async fn list_assets<S: Storage>(manager: &CommandManager, mut arguments: Argume
     let blockchain: &Arc<Blockchain<S>> = context.get()?;
     let storage = blockchain.get_storage().read().await;
     let assets = storage.get_assets().await.context("Error while retrieving assets")?;
+    if assets.is_empty() {
+        manager.message("No assets registered");
+        return Ok(());
+    }
+
     let mut max_pages = assets.len() / ELEMENTS_PER_PAGE;
     if assets.len() % ELEMENTS_PER_PAGE != 0 {
         max_pages += 1;
@@ -604,6 +619,11 @@ async fn show_stored_peerlist<S: Storage>(manager: &CommandManager, mut argument
         Some(p2p) => {
             let peer_list = p2p.get_peer_list();
             let peerlist: Vec<_> = peer_list.get_peerlist_entries().collect::<Result<Vec<_>, _>>().context("Error while retrieving stored peerlist")?;
+            if peerlist.is_empty() {
+                manager.message("No peers stored");
+                return Ok(());
+            }
+
             let mut max_pages = peerlist.len() / ELEMENTS_PER_PAGE;
             if peerlist.len() % ELEMENTS_PER_PAGE != 0 {
                 max_pages += 1;

--- a/xelis_daemon/src/main.rs
+++ b/xelis_daemon/src/main.rs
@@ -193,6 +193,7 @@ async fn run_prompt<S: Storage>(prompt: ShareablePrompt, blockchain: Arc<Blockch
     command_manager.add_command(Command::with_optional_arguments("list_miners", "List all miners connected", vec![Arg::new("page", ArgType::Number)], CommandHandler::Async(async_handler!(list_miners::<S>))))?;
     command_manager.add_command(Command::with_optional_arguments("list_peers", "List all peers connected", vec![Arg::new("page", ArgType::Number)], CommandHandler::Async(async_handler!(list_peers::<S>))))?;
     command_manager.add_command(Command::with_optional_arguments("list_assets", "List all assets registered on chain", vec![Arg::new("page", ArgType::Number)], CommandHandler::Async(async_handler!(list_assets::<S>))))?;
+    command_manager.add_command(Command::with_optional_arguments("show_stored_peerlist", "Show the stored peerlist", vec![Arg::new("page", ArgType::Number)], CommandHandler::Async(async_handler!(show_stored_peerlist::<S>))))?;
     command_manager.add_command(Command::with_arguments("show_balance", "Show balance of an address", vec![], vec![Arg::new("history", ArgType::Number)], CommandHandler::Async(async_handler!(show_balance::<S>))))?;
     command_manager.add_command(Command::with_required_arguments("print_block", "Print block in json format", vec![Arg::new("hash", ArgType::Hash)], CommandHandler::Async(async_handler!(print_block::<S>))))?;
     command_manager.add_command(Command::new("top_block", "Print top block", CommandHandler::Async(async_handler!(top_block::<S>))))?;
@@ -586,6 +587,45 @@ async fn list_assets<S: Storage>(manager: &CommandManager, mut arguments: Argume
     Ok(())
 }
 
+async fn show_stored_peerlist<S: Storage>(manager: &CommandManager, mut arguments: ArgumentManager) -> Result<(), CommandError> {
+    let page = if arguments.has_argument("page") {
+        arguments.get_value("page")?.to_number()? as usize
+    } else {
+        1
+    };
+
+    if page == 0 {
+        return Err(CommandError::InvalidArgument("Page must be greater than 0".to_string()));
+    }
+
+    let context = manager.get_context().lock()?;
+    let blockchain: &Arc<Blockchain<S>> = context.get()?;
+    match blockchain.get_p2p().read().await.as_ref() {
+        Some(p2p) => {
+            let peer_list = p2p.get_peer_list();
+            let peerlist: Vec<_> = peer_list.get_stored_peers().collect::<Result<Vec<_>, _>>().context("Error while retrieving stored peerlist")?;
+            let mut max_pages = peerlist.len() / ELEMENTS_PER_PAGE;
+            if peerlist.len() % ELEMENTS_PER_PAGE != 0 {
+                max_pages += 1;
+            }
+
+            if page > max_pages {
+                return Err(CommandError::InvalidArgument(format!("Page must be less than maximum pages ({})", max_pages - 1)));
+            }
+
+            manager.message(format!("Stored peerlist (total {}) page {}/{}:", peerlist.len(), page, max_pages));
+            for (ip, state) in peerlist.iter().skip((page - 1) * ELEMENTS_PER_PAGE).take(ELEMENTS_PER_PAGE) {
+                manager.message(format!("- {:15} | {}", ip, state));
+            }
+        },
+        None => {
+            manager.message("No P2p server running!");
+        }
+    };
+
+    Ok(())
+}
+
 async fn show_balance<S: Storage>(manager: &CommandManager, mut arguments: ArgumentManager) -> Result<(), CommandError> {
     let prompt = manager.get_prompt();
     // read address
@@ -822,7 +862,7 @@ async fn clear_p2p_peerlist<S: Storage>(manager: &CommandManager, _: ArgumentMan
     match blockchain.get_p2p().read().await.as_ref() {
         Some(p2p) => {
             let peerlist = p2p.get_peer_list();
-            peerlist.clear_peerlist().await;
+            peerlist.clear_peerlist().await.context("Error while clearing peerlist")?;
             manager.message("P2P peerlist cleared");
         },
         None => {
@@ -851,17 +891,16 @@ async fn blacklist<S: Storage>(manager: &CommandManager, mut arguments: Argument
             if arguments.has_argument("address") {
                 let address: IpAddr = arguments.get_value("address")?.to_string_value()?.parse().context("Error while parsing socket address")?;
                 let peer_list = p2p.get_peer_list();
-                if peer_list.is_blacklisted(&address).await {
-                    peer_list.set_graylist_for_peer(&address).await;
+                if peer_list.is_blacklisted(&address).await.context("Error while checking if peer is blacklisted")? {
+                    peer_list.set_graylist_for_peer(&address).await.context("Error while setting graylist")?;
                     manager.message(format!("Peer {} is not blacklisted anymore", address));
                 } else {
-                    peer_list.blacklist_address(&address).await;
+                    peer_list.blacklist_address(&address).await.context("Error while blacklisting peer")?;
                     manager.message(format!("Peer {} has been blacklisted", address));
                 }
             } else {
                 let peer_list = p2p.get_peer_list();
-                let stored_peers = peer_list.get_stored_peers().read().await;
-                let blacklist = peer_list.get_blacklist(&stored_peers);
+                let blacklist = peer_list.get_blacklist().context("Error while retrieving blacklist")?;
                 manager.message(format!("Current blacklist ({}):", blacklist.len()));
                 for (ip, peer) in blacklist {
                     manager.message(format!("- {}: {}", ip, peer));
@@ -884,17 +923,16 @@ async fn whitelist<S: Storage>(manager: &CommandManager, mut arguments: Argument
             if arguments.has_argument("address") {
                 let address: IpAddr = arguments.get_value("address")?.to_string_value()?.parse().context("Error while parsing socket address")?;
                 let peer_list = p2p.get_peer_list();
-                if peer_list.is_whitelisted(&address).await {
-                    peer_list.set_graylist_for_peer(&address).await;
+                if peer_list.is_whitelisted(&address).await.context("Error while checking if peer is whitelisted")? {
+                    peer_list.set_graylist_for_peer(&address).await.context("Error while setting graylist")?;
                     manager.message(format!("Peer {} is not whitelisted anymore", address));
                 } else {
-                    peer_list.whitelist_address(&address).await;
+                    peer_list.whitelist_address(&address).await.context("Error while whitelisting peer")?;
                     manager.message(format!("Peer {} has been whitelisted", address));
                 }
             } else {
                 let peer_list = p2p.get_peer_list();
-                let stored_peers = peer_list.get_stored_peers().read().await;
-                let whitelist = peer_list.get_whitelist(&stored_peers);
+                let whitelist = peer_list.get_whitelist().context("Error while retrieving whitelist")?;
                 manager.message(format!("Current whitelist ({}):", whitelist.len()));
                 for (ip, peer) in whitelist {
                     manager.message(format!("- {}: {}", ip, peer));

--- a/xelis_daemon/src/p2p/disk_cache.rs
+++ b/xelis_daemon/src/p2p/disk_cache.rs
@@ -1,0 +1,88 @@
+use std::net::IpAddr;
+
+use log::info;
+use sled::{Config, Db, Mode, Tree};
+use xelis_common::serializer::{ReaderError, Serializer};
+use thiserror::Error;
+
+use super::peer_list::StoredPeer;
+
+#[derive(Debug, Error)]
+pub enum DiskError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Sled error: {0}")]
+    Sled(#[from] sled::Error),
+    #[error("Not found")]
+    NotFound,
+    #[error("Read error: {0}")]
+    ReaderError(#[from] ReaderError),
+}
+
+pub struct DiskCache {
+    // All known peers
+    peerlist: Tree,
+    // DB to use
+    db: Db,
+}
+
+impl DiskCache {
+    pub fn new(filename: String) -> Result<Self, DiskError> {
+        let config = Config::new().temporary(false)
+            .path(filename)
+            .cache_capacity(16 * 1024)
+            .segment_size(256)
+            .mode(Mode::LowSpace);
+
+        let db = config.open()?;
+
+        Ok(Self {
+            peerlist: db.open_tree("peerlist")?,
+            db,
+        })
+    }
+
+    pub fn has_peer(&self, peer: &IpAddr) -> Result<bool, DiskError> {
+        Ok(self.peerlist.contains_key(peer.to_bytes())?)
+    }
+
+    pub fn set_stored_peer(&self, peer: &IpAddr, stored: StoredPeer) -> Result<(), DiskError> {
+        self.peerlist.insert(peer.to_bytes(), stored.to_bytes())?;
+        Ok(())
+    }
+
+    pub fn get_stored_peer(&self, peer: &IpAddr) -> Result<StoredPeer, DiskError> {
+        let v = self.peerlist.get(peer.to_bytes())?
+            .map(|v| StoredPeer::from_bytes(&v))
+            .ok_or(DiskError::NotFound)??;
+
+        Ok(v)
+    }
+
+    pub fn get_stored_peers(&self) -> impl Iterator<Item = Result<(IpAddr, StoredPeer), DiskError>> {
+        self.peerlist.iter()
+            .map(|r| {
+                let (k, v) = r?;
+                let ip = IpAddr::from_bytes(&k)?;
+                let stored = StoredPeer::from_bytes(&v)?;
+                Ok((ip, stored))
+            })
+    }
+
+    pub fn remove_peer(&self, peer: &IpAddr) -> Result<(), DiskError> {
+        self.peerlist.remove(peer.to_bytes())?;
+        Ok(())
+    }
+
+    pub async fn clear_peerlist(&self) -> Result<(), DiskError> {
+        self.peerlist.clear()?;
+        self.db.flush_async().await?;
+        Ok(())
+    }
+
+    pub async fn flush(&self) -> Result<(), DiskError> {
+        info!("Flushing Disk Cache");
+        self.db.flush_async().await?;
+        Ok(())
+    }
+}

--- a/xelis_daemon/src/p2p/disk_cache.rs
+++ b/xelis_daemon/src/p2p/disk_cache.rs
@@ -5,7 +5,7 @@ use sled::{Config, Db, Mode, Tree};
 use xelis_common::serializer::{ReaderError, Serializer};
 use thiserror::Error;
 
-use super::peer_list::StoredPeer;
+use super::peer_list::PeerListEntry;
 
 #[derive(Debug, Error)]
 pub enum DiskError {
@@ -19,6 +19,12 @@ pub enum DiskError {
     ReaderError(#[from] ReaderError),
 }
 
+// Previously, we were caching everything in the memory directly.
+// But over time, the memory usage will grow and be a problem for low devices.
+// DiskCache is a disk-based cache that stores the peerlist in the disk.
+// It uses sled as the underlying storage engine.
+// This means IO operations instead of memory operations.
+// Performance versus memory usage tradeoff.
 pub struct DiskCache {
     // All known peers
     peerlist: Tree,
@@ -27,6 +33,7 @@ pub struct DiskCache {
 }
 
 impl DiskCache {
+    // Create a new disk cache
     pub fn new(filename: String) -> Result<Self, DiskError> {
         let config = Config::new().temporary(false)
             .path(filename)
@@ -42,44 +49,52 @@ impl DiskCache {
         })
     }
 
-    pub fn has_peer(&self, peer: &IpAddr) -> Result<bool, DiskError> {
+    // Check if a peerlist entry is present in DB
+    pub fn has_peerlist_entry(&self, peer: &IpAddr) -> Result<bool, DiskError> {
         Ok(self.peerlist.contains_key(peer.to_bytes())?)
     }
 
-    pub fn set_stored_peer(&self, peer: &IpAddr, stored: StoredPeer) -> Result<(), DiskError> {
-        self.peerlist.insert(peer.to_bytes(), stored.to_bytes())?;
+    // Set a peer state using its IP address
+    pub fn set_peerlist_entry(&self, peer: &IpAddr, entry: PeerListEntry) -> Result<(), DiskError> {
+        self.peerlist.insert(peer.to_bytes(), entry.to_bytes())?;
         Ok(())
     }
 
-    pub fn get_stored_peer(&self, peer: &IpAddr) -> Result<StoredPeer, DiskError> {
+    // Get a PeerListEntry using its IP address
+    pub fn get_peerlist_entry(&self, peer: &IpAddr) -> Result<PeerListEntry, DiskError> {
         let v = self.peerlist.get(peer.to_bytes())?
-            .map(|v| StoredPeer::from_bytes(&v))
+            .map(|v| PeerListEntry::from_bytes(&v))
             .ok_or(DiskError::NotFound)??;
 
         Ok(v)
     }
 
-    pub fn get_stored_peers(&self) -> impl Iterator<Item = Result<(IpAddr, StoredPeer), DiskError>> {
+    // Get all entries of peerlist
+    // Returns an iterator to lazily load peers
+    pub fn get_peerlist_entries(&self) -> impl Iterator<Item = Result<(IpAddr, PeerListEntry), DiskError>> {
         self.peerlist.iter()
             .map(|r| {
                 let (k, v) = r?;
                 let ip = IpAddr::from_bytes(&k)?;
-                let stored = StoredPeer::from_bytes(&v)?;
-                Ok((ip, stored))
+                let entry = PeerListEntry::from_bytes(&v)?;
+                Ok((ip, entry))
             })
     }
 
-    pub fn remove_peer(&self, peer: &IpAddr) -> Result<(), DiskError> {
+    // Remove a peer from the peerlist
+    pub fn remove_peerlist_entry(&self, peer: &IpAddr) -> Result<(), DiskError> {
         self.peerlist.remove(peer.to_bytes())?;
         Ok(())
     }
 
+    // Clear the peerlist
     pub async fn clear_peerlist(&self) -> Result<(), DiskError> {
         self.peerlist.clear()?;
         self.db.flush_async().await?;
         Ok(())
     }
 
+    // Flush the cache to disk
     pub async fn flush(&self) -> Result<(), DiskError> {
         info!("Flushing Disk Cache");
         self.db.flush_async().await?;

--- a/xelis_daemon/src/p2p/error.rs
+++ b/xelis_daemon/src/p2p/error.rs
@@ -26,6 +26,7 @@ use std::{
 };
 use thiserror::Error;
 use super::{
+    disk_cache::DiskError,
     encryption::EncryptionError,
     packet::{
         bootstrap_chain::StepKind,
@@ -35,6 +36,8 @@ use super::{
 
 #[derive(Error, Debug)]
 pub enum P2pError {
+    #[error("disk error: {0}")]
+    DiskError(#[from] DiskError),
     #[error("Invalid P2P version: {}", _0)]
     InvalidP2pVersion(String),
     #[error("Invalid tag, it must be greater than 0 and maximum 16 chars")]

--- a/xelis_daemon/src/p2p/mod.rs
+++ b/xelis_daemon/src/p2p/mod.rs
@@ -465,7 +465,7 @@ impl<S: Storage> P2pServer<S> {
                     debug!("Error while connecting to address {}: {}", addr, e);
 
                     if !priority {
-                        if let Err(e) = self.peer_list.increase_fail_count_for_stored_peer(&addr.ip(), false).await {
+                        if let Err(e) = self.peer_list.increase_fail_count_for_peerlist_entry(&addr.ip(), false).await {
                             error!("Error while increasing fail count for peer {} while connecting to it: {}", addr, e);
                         }
                     }
@@ -479,7 +479,7 @@ impl<S: Storage> P2pServer<S> {
                 Err(e) => {
                     debug!("Error while verifying connection to address {}: {}", addr, e);
                     if !priority {
-                        if let Err(e) = self.peer_list.increase_fail_count_for_stored_peer(&addr.ip(), false).await {
+                        if let Err(e) = self.peer_list.increase_fail_count_for_peerlist_entry(&addr.ip(), false).await {
                             error!("Error while increasing fail count for peer {} while verifying it: {}", addr, e);
                         }
                     }
@@ -530,7 +530,7 @@ impl<S: Storage> P2pServer<S> {
                 },
                 Err(e) => {
                     debug!("Error while handling incoming connection {}: {}", addr, e);
-                    if let Err(e) = zelf.peer_list.increase_fail_count_for_stored_peer(&addr.ip(), true).await {
+                    if let Err(e) = zelf.peer_list.increase_fail_count_for_peerlist_entry(&addr.ip(), true).await {
                         error!("Error while increasing fail count for incoming peer {} while verifying it: {}", addr, e);
                     }
                 }

--- a/xelis_daemon/src/p2p/peer.rs
+++ b/xelis_daemon/src/p2p/peer.rs
@@ -579,7 +579,7 @@ impl Peer {
         {
             trace!("Locked peer list for temp ban {}", self);
             if !self.is_priority() {
-                self.peer_list.temp_ban_address(&self.get_connection().get_address().ip(), PEER_TEMP_BAN_TIME).await;
+                self.peer_list.temp_ban_address(&self.get_connection().get_address().ip(), PEER_TEMP_BAN_TIME).await?;
             } else {
                 debug!("{} is a priority peer, closing only", self);
             }

--- a/xelis_daemon/src/p2p/peer_list.rs
+++ b/xelis_daemon/src/p2p/peer_list.rs
@@ -1,30 +1,34 @@
 use crate::{
     config::{
         P2P_EXTEND_PEERLIST_DELAY,
-        PEER_FAIL_LIMIT,
         PEER_FAIL_TO_CONNECT_LIMIT,
         PEER_TEMP_BAN_TIME_ON_CONNECT,
     },
     p2p::packet::peer_disconnected::PacketPeerDisconnected
 };
-use super::{peer::Peer, packet::Packet, error::P2pError};
+use super::{
+    disk_cache::{DiskCache, DiskError},
+    error::P2pError,
+    packet::Packet,
+    peer::Peer
+};
 use std::{
-    collections::{hash_map::Entry, HashMap, HashSet},
+    collections::{HashMap, HashSet},
     fmt::{self, Display, Formatter},
-    fs, net::{IpAddr, SocketAddr},
+    net::{IpAddr, SocketAddr},
     time::Duration
 };
 use humantime::format_duration;
 use serde::{Serialize, Deserialize};
 use tokio::sync::{mpsc::Sender, RwLock};
 use xelis_common::{
-    serializer::Serializer,
-    time::{TimestampSeconds, get_current_time_in_seconds},
-    api::daemon::Direction
+    api::daemon::Direction,
+    serializer::{Reader, ReaderError, Serializer, Writer},
+    time::{get_current_time_in_seconds, TimestampSeconds}
 };
 use std::sync::Arc;
 use bytes::Bytes;
-use log::{info, debug, trace, error, warn};
+use log::{info, debug, trace, error};
 
 pub type SharedPeerList = Arc<PeerList>;
 
@@ -34,14 +38,13 @@ pub type SharedPeerList = Arc<PeerList>;
 pub struct PeerList {
     // Keep track of all connected peers
     peers: RwLock<HashMap<u64, Arc<Peer>>>,
-    // We only keep one "peer" per address in case the peer changes multiple
-    // times its local port
-    stored_peers: RwLock<HashMap<IpAddr, StoredPeer>>,
-    filename: String,
     // used to notify the server that a peer disconnected
     // this is done through a channel to not have to handle generic types
     // and to be flexible in the future
-    peer_disconnect_channel: Option<Sender<Arc<Peer>>>
+    peer_disconnect_channel: Option<Sender<Arc<Peer>>>,
+    // We only keep one "peer" per address in case the peer changes multiple
+    // times its local port
+    cache: DiskCache
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Eq)]
@@ -64,86 +67,26 @@ pub struct StoredPeer {
 }
 
 impl PeerList {
-    // load all the stored peers from the file
-    fn load_stored_peers(filename: &String) -> Result<HashMap<IpAddr, StoredPeer>, P2pError> {
-        // check that the file exists
-        if fs::metadata(filename).is_err() {
-            info!("Peerlist file not found, creating a new one");
-            let peers = HashMap::new();
-            // write empty set in file
-            fs::write(filename, serde_json::to_string_pretty(&peers)?)?;
-            return Ok(peers);
-        }
-
-        // read the whole file
-        let content = match fs::read_to_string(filename) {
-            Ok(content) => content,
-            Err(e) => {
-                error!("Error while reading peerlist file: {}", e);
-                warn!("Removing peerlist file and creating a new empty one");
-                fs::remove_file(filename)?;
-                let peers = HashMap::new();
-                // write empty set in file
-                fs::write(filename, serde_json::to_string_pretty(&peers)?)?;
-
-                return Ok(peers);
-            }
-        };
-
-        // deserialize the content
-        let mut peers: HashMap<IpAddr, StoredPeer> = match serde_json::from_str(&content) {
-            Ok(peers) => peers,
-            Err(e) => {
-                error!("Error while deserializing peerlist: {}", e);
-                warn!("Removing peerlist file and creating a new empty one");
-                fs::remove_file(filename)?;
-                let peers = HashMap::new();
-                // write empty set in file
-                fs::write(filename, serde_json::to_string_pretty(&peers)?)?;
-
-                peers
-            }
-        };
-
-        // reset the fail count of all whitelisted peers
-        for stored_peer in peers.values_mut() {
-            if *stored_peer.get_state() == StoredPeerState::Whitelist {
-                stored_peer.fail_count = 0;
-            }
-        }
-
-        Ok(peers)
-    }
-
-    pub fn new(capacity: usize, filename: String, peer_disconnect_channel: Option<Sender<Arc<Peer>>>) -> SharedPeerList {
-        let stored_peers = match Self::load_stored_peers(&filename) {
-            Ok(peers) => peers,
-            Err(e) => {
-                error!("Error while loading peerlist: {}", e);
-                info!("Creating a empty peerlist");
-                HashMap::new()
-            }
-        };
-
-        Arc::new(
+    pub fn new(capacity: usize, filename: String, peer_disconnect_channel: Option<Sender<Arc<Peer>>>) -> Result<SharedPeerList, P2pError> {
+        Ok(Arc::new(
             Self {
                 peers: RwLock::new(HashMap::with_capacity(capacity)),
-                stored_peers: RwLock::new(stored_peers),
-                filename,
-                peer_disconnect_channel
+                peer_disconnect_channel,
+                cache: DiskCache::new(filename)?
             }
-        )
+        ))
     }
 
     // Clear the peerlist, this will overwrite the file on disk also
-    pub async fn clear_peerlist(&self) {
+    pub async fn clear_peerlist(&self) -> Result<(), P2pError> {
         trace!("clear peerlist");
-        let mut stored_peers = self.stored_peers.write().await;
-        stored_peers.clear();
+        self.cache.clear_peerlist().await?;
+        Ok(())
+    }
 
-        if let Err(e) = self.save_peers_to_file(&stored_peers) {
-            error!("Error while trying to save peerlist to file: {}", e);
-        }
+    // Get the cache
+    pub fn get_cache(&self) -> &DiskCache {
+        &self.cache
     }
 
     // Remove a peer from the list
@@ -212,25 +155,30 @@ impl PeerList {
         }
         info!("New peer connected: {}", peer);
 
-        self.update_peer(&peer).await;
+        self.update_peer(&peer).await?;
 
         Ok(())
     }
 
-    async fn update_peer(&self, peer: &Peer) {
+    // Update a peer in the stored peerlist
+    async fn update_peer(&self, peer: &Peer) -> Result<(), P2pError> {
         let addr = peer.get_outgoing_address();
         let ip = addr.ip();
-        let mut stored_peers = self.stored_peers.write().await;
-        if let Some(stored_peer) = stored_peers.get_mut(&ip) {
+        if self.cache.has_peer(&ip)? {
+            let mut stored_peer = self.cache.get_stored_peer(&ip)?;
             debug!("Updating {} in stored peerlist", peer);
             // reset the fail count and update the last seen time
             stored_peer.set_fail_count(0);
             stored_peer.set_last_seen(get_current_time_in_seconds());
             stored_peer.set_local_port(peer.get_local_port());
+
+            self.cache.set_stored_peer(&ip, stored_peer)?;
         } else {
             debug!("Saving {} in stored peerlist", peer);
-            stored_peers.insert(ip, StoredPeer::new(peer.get_local_port(), StoredPeerState::Graylist));
+            self.cache.set_stored_peer(&ip, StoredPeer::new(peer.get_local_port(), StoredPeerState::Graylist))?;
         }
+
+        Ok(())
     }
 
     // Verify if the peer is connected (in peerlist)
@@ -240,9 +188,8 @@ impl PeerList {
     }
 
     // Check if the peer is known from our peerlist
-    pub async fn has_peer_stored(&self, ip: &IpAddr) -> bool {
-        let stored_peers = self.stored_peers.read().await;
-        stored_peers.contains_key(ip)
+    pub async fn has_peer_stored(&self, ip: &IpAddr) -> Result<bool, P2pError> {
+        Ok(self.cache.has_peer(ip)?)
     }
 
     pub fn get_peers(&self) -> &RwLock<HashMap<u64, Arc<Peer>>> {
@@ -250,8 +197,8 @@ impl PeerList {
     }
 
     // Get stored peers locked
-    pub fn get_stored_peers(&self) -> &RwLock<HashMap<IpAddr, StoredPeer>> {
-        &self.stored_peers
+    pub fn get_stored_peers(&self) -> impl Iterator<Item = Result<(IpAddr, StoredPeer), DiskError>> {
+        self.cache.get_stored_peers()
     }
 
     pub async fn get_cloned_peers(&self) -> HashSet<Arc<Peer>> {
@@ -279,9 +226,8 @@ impl PeerList {
             }
         }
 
-        let stored_peers = self.stored_peers.read().await;
-        if let Err(e) = self.save_peers_to_file(&stored_peers) {
-            error!("Error while trying to save peerlist to file: {}", e);
+        if let Err(e) = self.cache.flush().await {
+            error!("Error while flushing cache to disk: {}", e);
         }
     }
 
@@ -342,86 +288,103 @@ impl PeerList {
         Self::internal_get_peer_by_addr(&peers, peer_addr).is_some()
     }
 
-    pub async fn is_blacklisted(&self, ip: &IpAddr) -> bool {
+    // Is the ip blacklisted in the stored peerlist
+    pub async fn is_blacklisted(&self, ip: &IpAddr) -> Result<bool, P2pError> {
         self.addr_has_state(ip, StoredPeerState::Blacklist).await
     }
 
     // Verify that the peer is not blacklisted or temp banned
-    pub async fn is_allowed(&self, ip: &IpAddr) -> bool {
-        let stored_peers = self.stored_peers.read().await;
-        if let Some(stored_peer) = stored_peers.get(&ip) {
-            // If peer is blacklisted, don't accept it
-            return *stored_peer.get_state() != StoredPeerState::Blacklist
+    pub async fn is_allowed(&self, ip: &IpAddr) -> Result<bool, P2pError> {
+        if !self.cache.has_peer(ip)? {
+            return Ok(true);
+        }
+
+        let stored_peer = self.cache.get_stored_peer(&ip)?;
+        // If peer is blacklisted, don't accept it
+        return Ok(*stored_peer.get_state() != StoredPeerState::Blacklist
             // If it's still temp banned, don't accept it
             && stored_peer.get_temp_ban_until()
                 // Temp ban is lower than current time, he is not banned anymore
                 .map(|temp_ban_until| temp_ban_until < get_current_time_in_seconds())
                 // We don't have a temp ban, so he is not banned
                 .unwrap_or(true)
-        }
-
-        true
+        )
     }
 
-    pub async fn is_whitelisted(&self, ip: &IpAddr) -> bool {
+    // Verify if the peer is whitelisted in the stored peerlist
+    pub async fn is_whitelisted(&self, ip: &IpAddr) -> Result<bool, P2pError> {
         self.addr_has_state(ip, StoredPeerState::Whitelist).await
     }
 
-    async fn addr_has_state(&self, ip: &IpAddr, state: StoredPeerState) -> bool {
-        let stored_peers = self.stored_peers.read().await;
-        if let Some(stored_peer) = stored_peers.get(&ip) {
-            return *stored_peer.get_state() == state;
+    async fn addr_has_state(&self, ip: &IpAddr, state: StoredPeerState) -> Result<bool, P2pError> {
+        if self.cache.has_peer(ip)? {
+            let stored_peer = self.cache.get_stored_peer(ip)?;
+            return Ok(*stored_peer.get_state() == state);
         }
 
-        false
+        Ok(false)
     }
 
-    async fn set_state_to_address(&self, addr: &IpAddr, state: StoredPeerState) {
-        let mut stored_peers = self.stored_peers.write().await;
-        if let Some(stored_peer) = stored_peers.get_mut(addr) {
+    // Set the state of a peer address
+    async fn set_state_to_address(&self, addr: &IpAddr, state: StoredPeerState) -> Result<(), P2pError> {
+        if self.cache.has_peer(addr)? {
+            let mut stored_peer = self.cache.get_stored_peer(addr)?;
             stored_peer.set_state(state);
+            self.cache.set_stored_peer(addr, stored_peer)?;
         } else {
-            stored_peers.insert(addr.clone(), StoredPeer::new(0, state));
+            self.cache.set_stored_peer(addr, StoredPeer::new(0, state))?;
         }
+
+        Ok(())
     }
 
     // Set a peer to graylist, if its local port is 0, delete it from the stored peerlist
     // Because it was added manually and never connected to before
-    pub async fn set_graylist_for_peer(&self, ip: &IpAddr) {
-        let mut stored_peers = self.stored_peers.write().await;
-        let delete = if let Some(peer) = stored_peers.get_mut(ip) {
-            peer.set_state(StoredPeerState::Graylist);
-            peer.get_local_port() == 0
+    pub async fn set_graylist_for_peer(&self, ip: &IpAddr) -> Result<(), P2pError> {
+        let delete = if self.cache.has_peer(ip)? {
+            let mut stored_peer = self.cache.get_stored_peer(ip)?;
+            stored_peer.set_state(StoredPeerState::Graylist);
+            stored_peer.get_local_port() == 0
         } else {
             false
         };
 
         if delete {
             info!("Deleting {} from stored peerlist", ip);
-            stored_peers.remove(ip);
+            self.cache.remove_peer(ip)?;
         }
+
+        Ok(())
     }
 
-    fn get_list_with_state<'a>(&'a self, stored_peers: &'a HashMap<IpAddr, StoredPeer>, state: &StoredPeerState) -> Vec<(&'a IpAddr, &'a StoredPeer)> {
-        stored_peers.iter().filter(|(_, stored_peer)| *stored_peer.get_state() == *state).collect()
+    fn get_list_with_state(&self, state: &StoredPeerState) -> Result<Vec<(IpAddr, StoredPeer)>, P2pError> {
+        let mut values = Vec::new();
+        for res in self.cache.get_stored_peers() {
+            let (ip, stored_peer) = res?;
+            if stored_peer.get_state() == state {
+                values.push((ip, stored_peer));
+            }
+        }
+
+        Ok(values)
     }
 
     // Get all peers blacklisted from peerlist
-    pub fn get_blacklist<'a>(&'a self, stored_peers: &'a HashMap<IpAddr, StoredPeer>) -> Vec<(&'a IpAddr, &'a StoredPeer)> {
-        self.get_list_with_state(stored_peers, &StoredPeerState::Blacklist)
+    pub fn get_blacklist(&self) -> Result<Vec<(IpAddr, StoredPeer)>, P2pError> {
+        self.get_list_with_state(&StoredPeerState::Blacklist)
     }
 
     // Retrieve whitelist stored peers
-    pub fn get_whitelist<'a>(&'a self, stored_peers: &'a HashMap<IpAddr, StoredPeer>) -> Vec<(&'a IpAddr, &'a StoredPeer)> {
-        self.get_list_with_state(stored_peers, &StoredPeerState::Whitelist)
+    pub fn get_whitelist(&self) -> Result<Vec<(IpAddr, StoredPeer)>, P2pError> {
+        self.get_list_with_state(&StoredPeerState::Whitelist)
     }
 
     // blacklist a peer address
     // if this peer is already known, change its state to blacklist
     // otherwise create a new StoredPeer with state blacklist
     // disconnect the peer if present in peerlist
-    pub async fn blacklist_address(&self, ip: &IpAddr) {
-        self.set_state_to_address(ip, StoredPeerState::Blacklist).await;
+    pub async fn blacklist_address(&self, ip: &IpAddr) -> Result<(), P2pError> {
+        self.set_state_to_address(ip, StoredPeerState::Blacklist).await?;
 
         let potential_peer = {
             let peers = self.peers.read().await;
@@ -429,84 +392,83 @@ impl PeerList {
         };
 
         if let Some(peer) = potential_peer {
-            if let Err(e) = peer.signal_exit().await {
-                error!("Error while trying to close peer {} for being blacklisted: {}", peer.get_connection().get_address(), e);
-            }
-        }
-    }
-
-    // temp ban a peer for a duration in seconds
-    // this will also close the peer
-    pub async fn temp_ban_peer(&self, peer: &Peer, seconds: u64) {
-        self.temp_ban_address(&peer.get_connection().get_address().ip(), seconds).await;
-        if let Err(e) = peer.get_connection().close().await {
-            error!("Error while trying to close {} for being temp banned: {}", peer, e);
+            peer.signal_exit().await?;
         }
 
-        if let Err(e) = self.remove_peer(peer.get_id(), true).await {
-            error!("Error while removing peer from peerlist for being temp banned: {}", e);
-        }
+        Ok(())
     }
 
     // temp ban a peer address for a duration in seconds
-    pub async fn temp_ban_address(&self, ip: &IpAddr, seconds: u64) {
-        let mut stored_peers = self.stored_peers.write().await;
-        if let Some(stored_peer) = stored_peers.get_mut(ip) {
+    pub async fn temp_ban_address(&self, ip: &IpAddr, seconds: u64) -> Result<(), P2pError> {
+        if self.cache.has_peer(ip)? {
+            let mut stored_peer = self.cache.get_stored_peer(ip)?;
             stored_peer.set_temp_ban_until(Some(get_current_time_in_seconds() + seconds));
+            self.cache.set_stored_peer(ip, stored_peer)?;
         } else {
-            stored_peers.insert(ip.clone(), StoredPeer::new(0, StoredPeerState::Graylist));
+            self.cache.set_stored_peer(ip, StoredPeer::new(0, StoredPeerState::Graylist))?;
         }
+
+        Ok(())
     }
 
     // whitelist a peer address
     // if this peer is already known, change its state to whitelist
     // otherwise create a new StoredPeer with state whitelist
-    pub async fn whitelist_address(&self, ip: &IpAddr) {
-        self.set_state_to_address(ip, StoredPeerState::Whitelist).await;
+    pub async fn whitelist_address(&self, ip: &IpAddr) -> Result<(), P2pError> {
+        self.set_state_to_address(ip, StoredPeerState::Whitelist).await
     }
 
-    pub async fn find_peer_to_connect(&self) -> Option<SocketAddr> {
-        // remove all peers that have a high fail count
+    // Find a peer to connect to from the stored peerlist
+    // This will return None if no peer is found
+    // We will search for a whitelisted peer first, then a graylisted peer
+    // If a peer is found, we update its last connection try time
+    pub async fn find_peer_to_connect(&self) -> Result<Option<SocketAddr>, P2pError> {
         let peers = self.peers.read().await;
-        let mut stored_peers = self.stored_peers.write().await;
-        stored_peers.retain(|_, stored_peer| *stored_peer.get_state() == StoredPeerState::Whitelist || stored_peer.get_fail_count() < PEER_FAIL_LIMIT);
+        let stored_peers = self.cache.get_stored_peers();
 
         let current_time = get_current_time_in_seconds();
-        // first lets check in whitelist
-        if let Some(addr) = self.find_peer_to_connect_to_with_state(&peers, &mut stored_peers, current_time, StoredPeerState::Whitelist) {
-            return Some(addr);
-        }
 
-        // then in graylist
-        if let Some(addr) = self.find_peer_to_connect_to_with_state(&peers, &mut stored_peers, current_time, StoredPeerState::Graylist) {
-            return Some(addr);
-        }
-
-        None
-    }
-
-    // find among stored peers a peer to connect to with the requested StoredPeerState
-    // we check that we're not already connected to this peer and that we didn't tried to connect to it recently
-    fn find_peer_to_connect_to_with_state(&self, peers: &HashMap<u64, Arc<Peer>>, stored_peers: &mut HashMap<IpAddr, StoredPeer>, current_time: TimestampSeconds, state: StoredPeerState) -> Option<SocketAddr> {
-        for (ip, stored_peer) in stored_peers {
-            let addr = SocketAddr::new(*ip, stored_peer.get_local_port());
-            if *stored_peer.get_state() == state && stored_peer.get_last_connection_try() + (stored_peer.get_fail_count() as u64 * P2P_EXTEND_PEERLIST_DELAY) <= current_time && Self::internal_get_peer_by_addr(peers, &addr).is_none() {
-                stored_peer.set_last_connection_try(current_time);
-                return Some(addr);
+        // Search the first peer that we can connect to
+        let mut potential_gray_peer = None;
+        for res in stored_peers {
+            let (ip, mut stored_peer) = res?;
+            let addr = SocketAddr::new(ip, stored_peer.get_local_port());
+            if *stored_peer.get_state() != StoredPeerState::Blacklist && stored_peer.get_last_connection_try() + (stored_peer.get_fail_count() as u64 * P2P_EXTEND_PEERLIST_DELAY) <= current_time && Self::internal_get_peer_by_addr(&peers, &addr).is_none() {
+                // Store it if we don't have any whitelisted peer to connect to
+                if potential_gray_peer.is_none() && *stored_peer.get_state() == StoredPeerState::Graylist {
+                    potential_gray_peer = Some((ip, addr));
+                } else if *stored_peer.get_state() == StoredPeerState::Whitelist {
+                    debug!("Found peer to connect: {}, updating last connection try", addr);
+                    stored_peer.set_last_connection_try(current_time);
+                    self.cache.set_stored_peer(&ip, stored_peer)?;
+                    return Ok(Some(addr));
+                }
             }
         }
 
-        None
+        // If we didn't find a whitelisted peer, try to connect to a graylisted peer
+        Ok(match potential_gray_peer {
+            Some((ip, addr)) => {
+                debug!("Found gray peer to connect: {}, updating last connection try", addr);
+                let mut stored_peer = self.cache.get_stored_peer(&ip)?;
+                stored_peer.set_last_connection_try(current_time);
+                self.cache.set_stored_peer(&ip, stored_peer)?;
+                Some(addr)
+            },
+            None => None
+        })
     }
 
+
     // increase the fail count of a peer
-    pub async fn increase_fail_count_for_stored_peer(&self, ip: &IpAddr, temp_ban: bool) {
+    pub async fn increase_fail_count_for_stored_peer(&self, ip: &IpAddr, temp_ban: bool) -> Result<(), P2pError> {
         trace!("increasing fail count for {}, allow temp ban: {}", ip, temp_ban);
-        let mut stored_peers = self.stored_peers.write().await;
-        let stored_peer = match stored_peers.entry(*ip) {
-            Entry::Occupied(entry) => entry.into_mut(),
-            Entry::Vacant(entry) => entry.insert(StoredPeer::new(0, StoredPeerState::Graylist))
+        let mut stored_peer = if self.cache.has_peer(ip)? {
+            self.cache.get_stored_peer(ip)?
+        } else {
+            StoredPeer::new(0, StoredPeerState::Graylist)
         };
+
         let fail_count = stored_peer.get_fail_count();
         if *stored_peer.get_state() != StoredPeerState::Whitelist {
             if temp_ban && fail_count != 0 && fail_count % PEER_FAIL_TO_CONNECT_LIMIT == 0 {
@@ -516,31 +478,25 @@ impl PeerList {
 
             debug!("Increasing fail count for {}", ip);
             stored_peer.set_fail_count(fail_count.wrapping_add(1));
+
+            self.cache.set_stored_peer(ip, stored_peer)?;
         } else {
             debug!("{} is whitelisted, not increasing fail count", ip);
         }
+
+        Ok(())
     }
 
     // Store a new peer address into the peerlist file
-    pub async fn store_peer_address(&self, addr: SocketAddr) -> bool {
-        let mut stored_peers = self.stored_peers.write().await;
+    pub async fn store_peer_address(&self, addr: SocketAddr) -> Result<bool, P2pError> {
         let ip: IpAddr = addr.ip();
-        if stored_peers.contains_key(&ip) {
-            return false;
+        if self.cache.has_peer(&ip)? {
+            return Ok(false);
         }
 
-        stored_peers.insert(ip, StoredPeer::new(addr.port(), StoredPeerState::Graylist));
+        self.cache.set_stored_peer(&ip, StoredPeer::new(addr.port(), StoredPeerState::Graylist))?;
 
-        true
-    }
-
-    // serialize the stored peers to a file
-    fn save_peers_to_file(&self, stored_peers: &HashMap<IpAddr, StoredPeer>) -> Result<(), P2pError> {
-        trace!("saving peerlist to file");
-        let content = serde_json::to_string_pretty(&stored_peers)?;
-        fs::write(&self.filename, content)?;
-
-        Ok(())
+        Ok(true)
     }
 }
 
@@ -607,5 +563,56 @@ impl Display for StoredPeer {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let current_time = get_current_time_in_seconds();
         write!(f, "StoredPeer[first seen: {} ago, last seen: {} ago]", format_duration(Duration::from_secs(current_time - self.first_seen)), format_duration(Duration::from_secs(current_time - self.last_seen)))
+    }
+}
+
+impl Serializer for StoredPeerState {
+    fn write(&self, writer: &mut Writer) {
+        match self {
+            Self::Whitelist => writer.write_u8(0),
+            Self::Graylist => writer.write_u8(1),
+            Self::Blacklist => writer.write_u8(2)
+        }
+    }
+
+    fn read(reader: &mut Reader) -> Result<Self, ReaderError> {
+        Ok(match reader.read_u8()? {
+            0 => Self::Whitelist,
+            1 => Self::Graylist,
+            2 => Self::Blacklist,
+            _ => return Err(ReaderError::InvalidValue)
+        })
+    }
+}
+
+impl Serializer for StoredPeer {
+    fn write(&self, writer: &mut Writer) {
+        self.first_seen.write(writer);
+        self.last_seen.write(writer);
+        self.last_connection_try.write(writer);
+        self.fail_count.write(writer);
+        self.local_port.write(writer);
+        self.temp_ban_until.write(writer);
+        self.state.write(writer);
+    }
+
+    fn read(reader: &mut Reader) -> Result<Self, ReaderError> {
+        let first_seen = reader.read_u64()?;
+        let last_seen = reader.read_u64()?;
+        let last_connection_try = reader.read_u64()?;
+        let fail_count = reader.read_u8()?;
+        let local_port = reader.read_u16()?;
+        let temp_ban_until = Option::read(reader)?;
+        let state = StoredPeerState::read(reader)?;
+
+        Ok(Self {
+            first_seen,
+            last_seen,
+            last_connection_try,
+            fail_count,
+            local_port,
+            temp_ban_until,
+            state
+        })
     }
 }

--- a/xelis_miner/Cargo.toml
+++ b/xelis_miner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xelis_miner"
-version = "1.13.4"
+version = "1.14.0"
 edition = "2021"
 authors = ["Slixe <slixeprivate@gmail.com>"]
 

--- a/xelis_wallet/Cargo.toml
+++ b/xelis_wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xelis_wallet"
-version = "1.13.4"
+version = "1.14.0"
 edition = "2021"
 authors = ["Slixe <slixeprivate@gmail.com>"]
 

--- a/xelis_wallet/src/daemon_api.rs
+++ b/xelis_wallet/src/daemon_api.rs
@@ -172,6 +172,12 @@ impl DaemonAPI {
         Ok(info)
     }
 
+    pub async fn get_pruned_topoheight(&self) -> Result<Option<u64>> {
+        trace!("get_pruned_topoheight");
+        let topoheight = self.client.call("get_pruned_topoheight").await?;
+        Ok(topoheight)
+    }
+
     pub async fn get_asset(&self, asset: &Hash) -> Result<AssetData> {
         trace!("get_asset");
         let assets = self.client.call_with("get_asset", &GetAssetParams {

--- a/xelis_wallet/src/main.rs
+++ b/xelis_wallet/src/main.rs
@@ -412,6 +412,7 @@ async fn setup_wallet_command_manager(wallet: Arc<Wallet>, command_manager: &Com
     command_manager.add_command(Command::new("nonce", "Show current nonce", CommandHandler::Async(async_handler!(nonce))))?;
     command_manager.add_command(Command::new("set_nonce", "Set new nonce", CommandHandler::Async(async_handler!(set_nonce))))?;
     command_manager.add_command(Command::new("logout", "Logout from existing wallet", CommandHandler::Async(async_handler!(logout))))?;
+    command_manager.add_command(Command::new("clear_tx_cache", "Clear the current TX cache", CommandHandler::Async(async_handler!(clear_tx_cache))))?;
 
     #[cfg(feature = "network_handler")]
     {
@@ -897,6 +898,15 @@ async fn history(manager: &CommandManager, mut arguments: ArgumentManager) -> Re
         manager.message(format!("- {}", tx.summary(wallet.get_network().is_mainnet(), &*storage)?));
     }
 
+    Ok(())
+}
+
+async fn clear_tx_cache(manager: &CommandManager, _: ArgumentManager) -> Result<(), CommandError> {
+    let context = manager.get_context().lock()?;
+    let wallet: &Arc<Wallet> = context.get()?;
+    let mut storage = wallet.get_storage().write().await;
+    storage.clear_tx_cache();
+    manager.message("Transaction cache has been cleared");
     Ok(())
 }
 

--- a/xelis_wallet/src/main.rs
+++ b/xelis_wallet/src/main.rs
@@ -358,6 +358,7 @@ async fn apply_config(wallet: &Arc<Wallet>, #[cfg(feature = "api_server")] promp
     }
 
     wallet.set_history_scan(!config.disable_history_scan);
+    wallet.set_stable_balance(config.force_stable_balance);
 
     #[cfg(feature = "api_server")]
     {

--- a/xelis_wallet/src/network_handler.rs
+++ b/xelis_wallet/src/network_handler.rs
@@ -882,7 +882,7 @@ impl NetworkHandler {
                                     // TODO we should make a faster way to delete all TXs above this topoheight
                                     // Otherwise in future with millions of TXs, this may take few seconds.
                                     debug!("Deleting transactions above {} due to DAG reorg", topoheight);
-                                    storage.delete_transactions_above_topoheight(topoheight)?;
+                                    storage.delete_transactions_at_or_above_topoheight(topoheight)?;
                                 }
                             }
                         } else {

--- a/xelis_wallet/src/storage/mod.rs
+++ b/xelis_wallet/src/storage/mod.rs
@@ -704,6 +704,20 @@ impl EncryptedStorage {
         Ok(())
     }
 
+    // delete all transactions at or above the specified topoheight
+    pub fn delete_transactions_at_or_above_topoheight(&mut self, topoheight: u64) -> Result<()> {
+        trace!("delete transactions at or above topoheight {}", topoheight);
+        for el in self.transactions.iter().values() {
+            let value = el?;
+            let entry = TransactionEntry::from_bytes(&self.cipher.decrypt_value(&value)?)?;
+            if entry.get_topoheight() >= topoheight {
+                self.delete_transaction(entry.get_hash())?;
+            }
+        }
+
+        Ok(())
+    }
+
     // delete all transactions at the specified topoheight
     // This will go through each transaction, deserialize it, check topoheight, and delete it if required
     // Maybe we can optimize it by keeping a lookuptable of topoheight -> txs ?

--- a/xelis_wallet/src/wallet.rs
+++ b/xelis_wallet/src/wallet.rs
@@ -920,7 +920,7 @@ impl Wallet {
     // this function allow to user to get the network handler in case in want to stay in online mode
     // but want to pause / resume the syncing task through start/stop functions from it
     #[cfg(feature = "network_handler")]
-    pub async fn get_network_handler(&self) -> &Mutex<Option<Arc<NetworkHandler>>> {
+    pub fn get_network_handler(&self) -> &Mutex<Option<Arc<NetworkHandler>>> {
         &self.network_handler
     }
 

--- a/xelis_wallet/src/wallet.rs
+++ b/xelis_wallet/src/wallet.rs
@@ -897,8 +897,8 @@ impl Wallet {
                     debug!("Deleting all transactions for full rescan");
                     storage.delete_transactions()?;
                 } else {
-                    debug!("Deleting transactions above {} for partial rescan", topoheight);
-                    storage.delete_transactions_above_topoheight(topoheight)?;
+                    debug!("Deleting transactions at or above {} for partial rescan", topoheight);
+                    storage.delete_transactions_at_or_above_topoheight(topoheight)?;
                 }
             }
             debug!("Starting again network handler");

--- a/xelis_wallet/src/wallet.rs
+++ b/xelis_wallet/src/wallet.rs
@@ -76,7 +76,9 @@ use {
 };
 use rand::{rngs::OsRng, RngCore};
 use log::{
-    debug, error, info, trace
+    debug,
+    error,
+    trace
 };
 
 #[cfg(feature = "api_server")]
@@ -666,6 +668,7 @@ impl Wallet {
                                 ciphertext
                             };
 
+                            debug!("Setting unconfirmed balance for asset {} ({}) with amount {}", asset, balance.ciphertext, balance.amount);
                             storage.set_unconfirmed_balance_for((*asset).clone(), balance).await?;
                             // Build the stable reference
                             // We need to find the highest stable point
@@ -710,7 +713,7 @@ impl Wallet {
             }
 
             let (balance, unconfirmed) = storage.get_unconfirmed_balance_for(&asset).await?;
-            info!("Adding balance (unconfirmed: {}) for asset {} with amount {}, ciphertext: {}", unconfirmed, asset, balance.amount, balance.ciphertext);
+            debug!("Using balance (unconfirmed: {}) for asset {} with amount {}, ciphertext: {}", unconfirmed, asset, balance.amount, balance.ciphertext);
             state.add_balance(asset.clone(), balance);
         }
 

--- a/xelis_wallet/src/wallet.rs
+++ b/xelis_wallet/src/wallet.rs
@@ -640,7 +640,7 @@ impl Wallet {
                 if let Some(network_handler) = self.network_handler.lock().await.as_ref() {
                     // Last mining reward is above stable topoheight, this may increase orphans rate
                     // To avoid this, we will use the last balance version in stable topoheight as reference
-                    let use_stable_balance = if let Some(topoheight) = storage.get_last_coinbase_reward_topoheight() {
+                    let use_stable_balance = if let Some(topoheight) = storage.get_last_coinbase_reward_topoheight().filter(|_| !force_stable_balance) {
                         let stable_topoheight = network_handler.get_api().get_stable_topoheight().await?;
                         daemon_stable_topoheight = Some(stable_topoheight);
                         debug!("stable topoheight: {}, topoheight: {}", stable_topoheight, topoheight);


### PR DESCRIPTION
## Description

Moving to 1.14.0 due to breaking changes in peerlist storage.

Common:
- add new struct for `network_info` rpc method
- clean up in ws json rpc client

Daemon:
- add `get_pruned_topoheight` rpc method
- P2P peerlist is now backed by a DB instead of a traditional JSON file. (Reduce memory usage, and better I/O operations)
-  add `show_peerlist` cli command
- paginate few CLI commands
- don't keep Peer instance in chain sync task, but its priority flag & id only.

Wallet:
- `network_info` rpc method added
- fix `force-stable-balance` CLI option
- add `clear_tx_cache` cli command
- fix blockDAG reorg resync of transactions
- support anonymous browsing for web wallet (no access to directory feature)

## Type of change

Please select the right one.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update

## Which part is impacted ?

  - [X] Daemon
  - [X] Wallet
  - [ ] Miner
  - [X] Misc (documentation, comments, text...)

## Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings